### PR TITLE
Store test results on candidate model and enforce requirements

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -5,6 +5,8 @@ namespace App\Actions\Fortify;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Jetstream\Jetstream;
 
@@ -19,6 +21,19 @@ class CreateNewUser implements CreatesNewUsers
      */
     public function create(array $input): User
     {
+        $testData = Session::get('guest_test_data');
+        if (!$testData || !isset($testData['bmi'], $testData['blind_test'])) {
+            throw ValidationException::withMessages([
+                'email' => 'Silakan lakukan tes BMI dan tes buta warna terlebih dahulu.',
+            ]);
+        }
+
+        if (($testData['bmi']['kategori'] ?? '') !== 'Normal' || ($testData['blind_test']['score'] ?? 0) < 60) {
+            throw ValidationException::withMessages([
+                'email' => 'Hasil tes BMI atau tes buta warna tidak memenuhi syarat.',
+            ]);
+        }
+
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],

--- a/app/Listeners/ProcessGuestTestData.php
+++ b/app/Listeners/ProcessGuestTestData.php
@@ -5,8 +5,6 @@ namespace App\Listeners;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use App\Models\Kandidat;
-use App\Models\BmiTest;
-use App\Models\BlindTest;
 use App\Models\LamarLowongan;
 use Illuminate\Support\Facades\Session;
 
@@ -32,14 +30,16 @@ class ProcessGuestTestData
             $testData = Session::get('guest_test_data');
 
             // Simpan data BMI jika ada di sesi dan belum ada di DB
-            if (isset($testData['bmi']) && !$kandidat->bmiTest) {
-                BmiTest::create(array_merge(['kandidat_id' => $kandidat->id], $testData['bmi']));
+            if (isset($testData['bmi']) && !$kandidat->bmi_score) {
+                $kandidat->bmi_score = $testData['bmi']['score'];
             }
 
             // Simpan data Blind Test jika ada di sesi dan belum ada di DB
-            if (isset($testData['blind_test']) && !$kandidat->blindTest) {
-                BlindTest::create(array_merge(['kandidat_id' => $kandidat->id], $testData['blind_test']));
+            if (isset($testData['blind_test']) && !$kandidat->blind_score) {
+                $kandidat->blind_score = $testData['blind_test']['score'];
             }
+
+            $kandidat->save();
             
             // Jika ada ID lowongan, lamarkan pekerjaan
             $jobId = Session::get('guest_application_job_id');

--- a/app/Livewire/Profile/ShowProfile.php
+++ b/app/Livewire/Profile/ShowProfile.php
@@ -2,7 +2,6 @@
 
 namespace App\Livewire\Profile;
 
-use App\Models\BmiTest;
 use App\Models\Kandidat;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
@@ -14,7 +13,7 @@ class ShowProfile extends Component
     public function mount()
     {
         // Mengambil data user yang sedang login beserta relasi 'kandidat'
-        $user = Auth::user()->load('kandidat', 'kandidat.bmiTest', 'kandidat.blindTest');
+        $user = Auth::user()->load('kandidat');
         $this->kandidat = $user->kandidat;
     }
 

--- a/app/Livewire/Profile/UpdateKandidatProfileForm.php
+++ b/app/Livewire/Profile/UpdateKandidatProfileForm.php
@@ -30,7 +30,7 @@ class UpdateKandidatProfileForm extends Component
      */
     public function mount()
     {
-        $user = Auth::user()->load('kandidat.bmiTest', 'kandidat.blindTest');
+        $user = Auth::user()->load('kandidat');
         $this->kandidat = $user->kandidat;
 
         if ($this->kandidat) {

--- a/app/Models/Kandidat.php
+++ b/app/Models/Kandidat.php
@@ -33,8 +33,8 @@ class Kandidat extends Model
         'jenis_kelamin',
         'status_perkawinan',
         'agama',
-        // 'bmi_score',
-        // 'blind_score',
+        'bmi_score',
+        'blind_score',
         'no_telpon_alternatif',
         'pengalaman_kerja',
         'pendidikan',
@@ -85,30 +85,12 @@ class Kandidat extends Model
     }
 
     /**
-     * Relasi dengan hasil BMI Test
-     * Satu kandidat memiliki satu hasil BMI Test
-     */
-    public function bmiTest()
-    {
-        return $this->hasOne(BmiTest::class);
-    }
-
-    /**
-     * Relasi dengan hasil Blind Test
-     * Satu kandidat memiliki satu hasil Blind Test
-     */
-    public function blindTest()
-    {
-        return $this->hasOne(BlindTest::class);
-    }
-
-    /**
      * Check apakah kandidat sudah menyelesaikan semua tes yang diperlukan
      * @return bool
      */
     public function hasCompletedAllTests()
     {
-        return $this->bmiTest()->exists() && $this->blindTest()->exists();
+        return $this->hasCompletedBmiTest() && $this->hasCompletedBlindTest();
     }
 
     /**
@@ -117,7 +99,7 @@ class Kandidat extends Model
      */
     public function hasCompletedBmiTest()
     {
-        return $this->bmiTest()->exists();
+        return !is_null($this->bmi_score);
     }
 
     /**
@@ -126,7 +108,7 @@ class Kandidat extends Model
      */
     public function hasCompletedBlindTest()
     {
-        return $this->blindTest()->exists();
+        return !is_null($this->blind_score);
     }
 
     /**
@@ -135,10 +117,12 @@ class Kandidat extends Model
      */
     public function getBmiCategoryAttribute()
     {
-        if (!$this->bmiTest) {
+        if (is_null($this->bmi_score)) {
             return null;
         }
-        return $this->bmiTest->kategori;
+
+        $score = (float) $this->bmi_score;
+        return ($score < 18.5) ? 'Kurus' : (($score <= 24.9) ? 'Normal' : 'Gemuk');
     }
 
     /**
@@ -147,10 +131,28 @@ class Kandidat extends Model
      */
     public function getBlindTestPercentageAttribute()
     {
-        if (!$this->blindTest) {
+        return $this->blind_score ? (int) $this->blind_score : null;
+    }
+
+    /**
+     * Get Blind test status
+     * @return string|null
+     */
+    public function getBlindTestStatusAttribute()
+    {
+        if (is_null($this->blind_score)) {
             return null;
         }
-        return $this->blindTest->score;
+
+        $score = (int) $this->blind_score;
+        if ($score >= 80) {
+            return 'Excellent';
+        } elseif ($score >= 60) {
+            return 'Good';
+        } elseif ($score >= 40) {
+            return 'Fair';
+        }
+        return 'Poor';
     }
     public function lamarLowongans()
     {

--- a/resources/views/livewire/kandidat/dashboard.blade.php
+++ b/resources/views/livewire/kandidat/dashboard.blade.php
@@ -314,6 +314,38 @@
     <div class="modal-backdrop fade show"></div>
     @endif
 
+    {{-- MODAL RESULT TEST: Tampilkan Hasil Tes dari Cache --}}
+    @if($showResultModal)
+    <div class="modal fade show" style="display: block; background-color: rgba(0,0,0,0.5);" tabindex="-1" wire:ignore.self>
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content rounded shadow-lg">
+                <div class="modal-header p-4">
+                    <h5 class="modal-title fw-bold">Hasil Tes</h5>
+                    <button type="button" class="btn-close" wire:click="closeResultModal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body p-4">
+                    @if(isset($testResults['bmi']))
+                        <p class="mb-2">Skor BMI: {{ $testResults['bmi']['score'] }} ({{ $testResults['bmi']['kategori'] }})</p>
+                    @endif
+                    @if(isset($testResults['blind']))
+                        <p class="mb-0">Skor Tes Buta Warna: {{ $testResults['blind']['score'] }}%</p>
+                    @endif
+                    @if(isset($testResults['bmi']) && $testResults['bmi']['kategori'] !== 'Normal')
+                        <div class="alert alert-danger mt-3">Hasil BMI Anda tidak memenuhi syarat pendaftaran.</div>
+                    @endif
+                    @if(isset($testResults['blind']) && $testResults['blind']['score'] < 60)
+                        <div class="alert alert-danger">Hasil tes buta warna Anda tidak memenuhi syarat pendaftaran.</div>
+                    @endif
+                </div>
+                <div class="modal-footer p-3 bg-light">
+                    <button type="button" class="btn btn-primary" wire:click="closeResultModal">Lanjutkan</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal-backdrop fade show"></div>
+    @endif
+
     {{-- MODAL PROFILE: Untuk Lengkapi Data Profil --}}
     @if($showProfileModal)
     <div class="modal fade show" style="display: block; background-color: rgba(0,0,0,0.5);" tabindex="-1" wire:ignore.self>
@@ -452,26 +484,26 @@
                             </div>
                             
                             {{-- Data Hasil Tes (Tampilkan jika sudah ada) --}}
-                            @if(Auth::user()->kandidat && (Auth::user()->kandidat->bmiTest || Auth::user()->kandidat->blindTest))
+                            @if(Auth::user()->kandidat && (Auth::user()->kandidat->bmi_score || Auth::user()->kandidat->blind_score))
                             <div class="col-12 mb-4 mt-4">
                                 <h6 class="fw-bold text-primary border-bottom pb-2">Hasil Tes</h6>
                             </div>
                             
-                            @if(Auth::user()->kandidat->bmiTest)
+                            @if(Auth::user()->kandidat->bmi_score)
                             <div class="col-md-6 mb-3">
                                 <label class="form-label">BMI Score</label>
                                 <div class="input-group">
-                                    <input type="text" class="form-control" value="{{ Auth::user()->kandidat->bmiTest->score }}" readonly>
-                                    <span class="input-group-text">{{ Auth::user()->kandidat->bmiTest->kategori }}</span>
+                                    <input type="text" class="form-control" value="{{ Auth::user()->kandidat->bmi_score }}" readonly>
+                                    <span class="input-group-text">{{ Auth::user()->kandidat->bmi_category }}</span>
                                 </div>
                             </div>
                             @endif
-                            
-                            @if(Auth::user()->kandidat->blindTest)
+
+                            @if(Auth::user()->kandidat->blind_score)
                             <div class="col-md-6 mb-3">
                                 <label class="form-label">Blind Test Score</label>
                                 <div class="input-group">
-                                    <input type="text" class="form-control" value="{{ Auth::user()->kandidat->blindTest->score }}" readonly>
+                                    <input type="text" class="form-control" value="{{ Auth::user()->kandidat->blind_score }}" readonly>
                                     <span class="input-group-text">%</span>
                                 </div>
                             </div>

--- a/resources/views/livewire/profile/show-profile.blade.php
+++ b/resources/views/livewire/profile/show-profile.blade.php
@@ -56,59 +56,59 @@
                                         </h6>
                                     </div>
 
-                                    @if ($kandidat->bmiTest || $kandidat->blindTest)
+                                    @if ($kandidat->bmi_score || $kandidat->blind_score)
 
-                                        @if ($kandidat->bmiTest)
+                                        @if ($kandidat->bmi_score)
                                         <div class="col-md-6 mb-3">
                                             <h6 class="text-muted mb-0">Skor BMI</h6>
-                                            <p class="fw-medium fs-5">{{ $kandidat->bmiTest->score }}</p>
+                                            <p class="fw-medium fs-5">{{ $kandidat->bmi_score }}</p>
                                         </div>
                                         <div class="col-md-6 mb-3">
                                             <h6 class="text-muted mb-0">Kategori BMI</h6>
                                             {{-- =================== INDIKATOR WARNA BMI =================== --}}
                                             <p class="fs-5">
-                                                @switch($kandidat->bmiTest->kategori)
+                                                @switch($kandidat->bmi_category)
                                                     @case('Kurus')
-                                                        <span class="badge bg-soft-warning">{{ $kandidat->bmiTest->kategori }}</span>
+                                                        <span class="badge bg-soft-warning">{{ $kandidat->bmi_category }}</span>
                                                         @break
                                                     @case('Normal')
-                                                        <span class="badge bg-soft-success">{{ $kandidat->bmiTest->kategori }}</span>
+                                                        <span class="badge bg-soft-success">{{ $kandidat->bmi_category }}</span>
                                                         @break
                                                     @case('Gemuk')
-                                                        <span class="badge bg-soft-danger">{{ $kandidat->bmiTest->kategori }}</span>
+                                                        <span class="badge bg-soft-danger">{{ $kandidat->bmi_category }}</span>
                                                         @break
                                                     @default
-                                                        <span class="badge bg-soft-secondary">{{ $kandidat->bmiTest->kategori }}</span>
+                                                        <span class="badge bg-soft-secondary">{{ $kandidat->bmi_category }}</span>
                                                 @endswitch
                                             </p>
                                             {{-- ========================================================= --}}
                                         </div>
                                         @endif
 
-                                        @if ($kandidat->blindTest)
+                                        @if ($kandidat->blind_score)
                                         <div class="col-md-6 mb-3">
                                             <h6 class="text-muted mb-0">Skor Tes Buta Warna</h6>
-                                            <p class="fw-medium fs-5">{{ $kandidat->blindTest->score }}%</p>
+                                            <p class="fw-medium fs-5">{{ $kandidat->blind_score }}%</p>
                                         </div>
                                         <div class="col-md-6 mb-3">
                                             <h6 class="text-muted mb-0">Status Tes Buta Warna</h6>
                                             {{-- =================== INDIKATOR WARNA BUTA WARNA =================== --}}
                                             <p class="fs-5">
-                                                @switch($kandidat->blindTest->status)
+                                                @switch($kandidat->blind_test_status)
                                                     @case('Excellent')
-                                                        <span class="badge bg-soft-success">{{ $kandidat->blindTest->status }}</span>
+                                                        <span class="badge bg-soft-success">{{ $kandidat->blind_test_status }}</span>
                                                         @break
                                                     @case('Good')
-                                                        <span class="badge bg-soft-primary">{{ $kandidat->blindTest->status }}</span>
+                                                        <span class="badge bg-soft-primary">{{ $kandidat->blind_test_status }}</span>
                                                         @break
                                                     @case('Fair')
-                                                        <span class="badge bg-soft-warning">{{ $kandidat->blindTest->status }}</span>
+                                                        <span class="badge bg-soft-warning">{{ $kandidat->blind_test_status }}</span>
                                                         @break
                                                     @case('Poor')
-                                                        <span class="badge bg-soft-danger">{{ $kandidat->blindTest->status }}</span>
+                                                        <span class="badge bg-soft-danger">{{ $kandidat->blind_test_status }}</span>
                                                         @break
                                                     @default
-                                                        <span class="badge bg-soft-secondary">{{ $kandidat->blindTest->status }}</span>
+                                                        <span class="badge bg-soft-secondary">{{ $kandidat->blind_test_status }}</span>
                                                 @endswitch
                                             </p>
                                             {{-- ============================================================== --}}

--- a/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
+++ b/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
@@ -47,7 +47,7 @@
                         </div>
                         
                         <form wire:submit.prevent="updateKandidatProfile" class="card-body p-4">
-                            @if ($this->kandidat && ($this->kandidat->bmiTest || $this->kandidat->blindTest))
+                            @if ($this->kandidat && ($this->kandidat->bmi_score || $this->kandidat->blind_score))
                                 <div class="row">
                                     <div class="col-12 mb-4">
                                         <h6 class="fw-bold text-primary border-bottom pb-2">
@@ -58,15 +58,15 @@
                                     <div class="col-md-6 mb-3">
                                         <label class="form-label">{{ __('Skor BMI') }}</label>
                                         <div class="input-group">
-                                            <input type="text" class="form-control" value="{{ $this->kandidat->bmiTest->score }}" readonly>
-                                            <span class="input-group-text">{{ $this->kandidat->bmiTest->kategori }}</span>
+                                            <input type="text" class="form-control" value="{{ $this->kandidat->bmi_score }}" readonly>
+                                            <span class="input-group-text">{{ $this->kandidat->bmi_category }}</span>
                                         </div>
                                     </div>
 
                                     <div class="col-md-6 mb-3">
                                         <label class="form-label">{{ __('Skor Tes Buta Warna') }}</label>
                                         <div class="input-group">
-                                            <input type="text" class="form-control" value="{{ $this->kandidat->blindTest->score }}" readonly>
+                                            <input type="text" class="form-control" value="{{ $this->kandidat->blind_score }}" readonly>
                                             <span class="input-group-text">%</span>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Summary
- Save BMI and blind test scores directly on `Kandidat` instead of separate models
- Block registration when cached test results fail BMI or blind-test thresholds
- Show cached test results after guest testing and import them on registration

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e8df3fda48326b80ede22d2ccbc54