### PR TITLE
Handle failed health tests with info modal

### DIFF
--- a/app/Livewire/Kandidat/Dashboard.php
+++ b/app/Livewire/Kandidat/Dashboard.php
@@ -246,7 +246,15 @@ class Dashboard extends Component
     public function closeResultModal()
     {
         $this->showResultModal = false;
-        $this->dispatch('prompt-auth-after-test');
+
+        $meetsBmi = isset($this->testResults['bmi']) &&
+            ($this->testResults['bmi']['kategori'] === 'Normal');
+        $meetsBlind = isset($this->testResults['blind']) &&
+            ($this->testResults['blind']['score'] >= 60);
+
+        if ($meetsBmi && $meetsBlind) {
+            $this->dispatch('prompt-auth-after-test');
+        }
     }
 
     private function resetBlindTest()

--- a/resources/views/livewire/kandidat/dashboard.blade.php
+++ b/resources/views/livewire/kandidat/dashboard.blade.php
@@ -330,15 +330,26 @@
                     @if(isset($testResults['blind']))
                         <p class="mb-0">Skor Tes Buta Warna: {{ $testResults['blind']['score'] }}%</p>
                     @endif
-                    @if(isset($testResults['bmi']) && $testResults['bmi']['kategori'] !== 'Normal')
+                    @php
+                        $bmiInvalid = isset($testResults['bmi']) && $testResults['bmi']['kategori'] !== 'Normal';
+                        $blindInvalid = isset($testResults['blind']) && $testResults['blind']['score'] < 60;
+                    @endphp
+                    @if($bmiInvalid)
                         <div class="alert alert-danger mt-3">Hasil BMI Anda tidak memenuhi syarat pendaftaran.</div>
                     @endif
-                    @if(isset($testResults['blind']) && $testResults['blind']['score'] < 60)
+                    @if($blindInvalid)
                         <div class="alert alert-danger">Hasil tes buta warna Anda tidak memenuhi syarat pendaftaran.</div>
+                    @endif
+                    @if($bmiInvalid || $blindInvalid)
+                        <div class="alert alert-warning mt-3">Anda tidak dapat melanjutkan tahap registrasi.</div>
                     @endif
                 </div>
                 <div class="modal-footer p-3 bg-light">
-                    <button type="button" class="btn btn-primary" wire:click="closeResultModal">Lanjutkan</button>
+                    @if(!$bmiInvalid && !$blindInvalid)
+                        <button type="button" class="btn btn-primary" wire:click="closeResultModal">Lanjutkan</button>
+                    @else
+                        <button type="button" class="btn btn-secondary" wire:click="closeResultModal">Tutup</button>
+                    @endif
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- show information modal when BMI or color-blind tests fail
- only prompt for login if health tests passed

## Testing
- `php artisan test` *(fails: require(/workspace/jobportal/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: failed to download packages; GitHub token required)*

------
https://chatgpt.com/codex/tasks/task_e_689e9b6b793c8326bc5a1ec3d254adc0