### PR TITLE
Handle failed health tests with info modal

### DIFF
--- a/app/Livewire/Kandidat/Dashboard.php
+++ b/app/Livewire/Kandidat/Dashboard.php
@@ -196,14 +196,24 @@ class Dashboard extends Component
             $this->showProfileModal = true;
         } else {
             // Simpan data Blind Test ke sesi server
-            $blindTestData = ['total_questions' => $this->total_blind_tests, 'correct_answers' => $correctCount, 'score' => $score, 'details' => $this->blind_test_answers];
-            session(['guest_test_data.blind_test' => $blindTestData]);
-            $this->testResults = [
+            $blindTestData = [
+                'total_questions' => $this->total_blind_tests,
+                'correct_answers' => $correctCount,
+                'score' => $score,
+                'details' => $this->blind_test_answers,
+            ];
+
+            $results = [
                 'bmi' => session('guest_test_data.bmi'),
                 'blind' => $blindTestData,
             ];
+
+            session(['guest_test_data' => $results]);
+            $this->testResults = $results;
             $this->showBlindTestModal = false;
             $this->showResultModal = true;
+
+            $this->dispatch('store-test-results', $results);
         }
     }
     }
@@ -246,7 +256,15 @@ class Dashboard extends Component
     public function closeResultModal()
     {
         $this->showResultModal = false;
-        $this->dispatch('prompt-auth-after-test');
+
+        $meetsBmi = isset($this->testResults['bmi']) &&
+            ($this->testResults['bmi']['kategori'] === 'Normal');
+        $meetsBlind = isset($this->testResults['blind']) &&
+            ($this->testResults['blind']['score'] >= 60);
+
+        if ($meetsBmi && $meetsBlind) {
+            $this->dispatch('prompt-auth-after-test');
+        }
     }
 
     private function resetBlindTest()
@@ -341,16 +359,33 @@ class Dashboard extends Component
         ]);
     }
 
-    protected $listeners = ['start-guest-test-flow' => 'startGuestTestFlow'];
+    protected $listeners = [
+        'start-guest-test-flow' => 'startGuestTestFlow',
+        'show-cached-results' => 'showCachedResults',
+    ];
 
     public function startGuestTestFlow($data = [])
     {
+        if (session()->has('guest_test_data')) {
+            $this->testResults = session('guest_test_data');
+            $this->showResultModal = true;
+            return;
+        }
+
         if (isset($data['jobId'])) {
             $this->selectedLowongan = Lowongan::find($data['jobId']);
             // Simpan ID lowongan di sesi untuk tamu
             session(['guest_application_job_id' => $data['jobId']]);
         }
         $this->showBmiTestModal = true;
+    }
+
+    public function showCachedResults($data)
+    {
+        if (!$data) return;
+
+        $this->testResults = $data;
+        $this->showResultModal = true;
     }
 
     public function importTestData($data)


### PR DESCRIPTION
## Summary
- persist guest BMI and color-blind test results in session and localStorage
- block login/register prompts when cached health tests don't meet requirements

## Testing
- `composer install --no-progress --no-interaction` *(fails: unable to clone github.com/Bacon/BaconQrCode.git — CONNECT tunnel failed)*
- `php artisan test` *(fails: require(/workspace/jobportal/vendor/autoload.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e9b6b793c8326bc5a1ec3d254adc0