### PR TITLE
feat: schedule interviews with zoom and notes

### DIFF
--- a/app/Livewire/Kandidat/LowonganDilamar/Index.php
+++ b/app/Livewire/Kandidat/LowonganDilamar/Index.php
@@ -19,7 +19,7 @@ class Index extends Component
         // Pastikan relasi kandidat->lamarLowongans ada
         $query = $user->kandidat
             ->lamarLowongans()
-            ->with(['lowongan', 'progressRekrutmen'])
+            ->with(['lowongan', 'progressRekrutmen.officer'])
             ->when($this->search, function ($q) {
                 $q->whereHas('lowongan', function ($qq) {
                     $qq->where('nama_posisi', 'like', '%' . $this->search . '%');

--- a/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
+++ b/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
@@ -1,4 +1,5 @@
 <div>
+    @php use Illuminate\Support\Facades\Storage; @endphp
     <!-- Hero Start -->
     <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
         <div class="bg-overlay bg-gradient-overlay"></div>
@@ -169,13 +170,29 @@
                                                     </div>
                                                 @endif
 
-                                                <!-- Zoom Meeting Button -->
-                                                @if($doneInterview && ($latestInterview && !empty($latestInterview->link_zoom)))
+                                                <!-- Info Interview -->
+                                                @if($doneInterview && $latestInterview)
                                                     <div class="mt-2">
-                                                        <a href="{{ $latestInterview->link_zoom }}" target="_blank" rel="noopener"
-                                                           class="btn btn-sm btn-primary">
-                                                            <i class="mdi mdi-video me-1"></i>Join Zoom
-                                                        </a>
+                                                        @if($latestInterview->waktu_pelaksanaan)
+                                                            <div class="small text-muted">Waktu: {{ $latestInterview->waktu_pelaksanaan->format('d M Y H:i') }}</div>
+                                                        @endif
+                                                        @if($latestInterview->officer)
+                                                            <div class="small text-muted">Interviewer: {{ $latestInterview->officer->name }}</div>
+                                                        @endif
+                                                        @if($latestInterview->link_zoom)
+                                                            <a href="{{ $latestInterview->link_zoom }}" target="_blank" rel="noopener"
+                                                               class="btn btn-sm btn-primary mt-1">
+                                                                <i class="mdi mdi-video me-1"></i>Join Zoom
+                                                            </a>
+                                                        @endif
+                                                        @if($latestInterview->catatan)
+                                                            <div class="mt-2"><strong>Catatan:</strong> {{ $latestInterview->catatan }}</div>
+                                                        @endif
+                                                        @if($latestInterview->dokumen_pendukung)
+                                                            <div class="mt-1">
+                                                                <a href="{{ Storage::url($latestInterview->dokumen_pendukung) }}" target="_blank">Dokumen Pendukung</a>
+                                                            </div>
+                                                        @endif
                                                     </div>
                                                 @endif
                                             </div>


### PR DESCRIPTION
## Summary
- add interview scheduling with zoom link, time, and interviewer
- allow officers to upload interview notes and documents
- show interview details and notes to candidates

## Testing
- `php artisan test` *(fails: Failed to open required '/workspace/jobportal/vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d0d0084c8326857335e273933d26