### PR TITLE
Restrict CBT access to psychotest candidates

### DIFF
--- a/app/Livewire/Cbt/Test.php
+++ b/app/Livewire/Cbt/Test.php
@@ -68,8 +68,23 @@ class Test extends Component
     }
 
     public function mount()
-    {   
-        
+    {
+        $user = Auth::user();
+        $kandidat = $user->kandidat;
+
+        $hasPsikotes = false;
+        if ($kandidat) {
+            $hasPsikotes = $kandidat->lamarLowongans()
+                ->whereHas('progressRekrutmen', function ($q) {
+                    $q->where('status', 'psikotes');
+                })
+                ->exists();
+        }
+
+        if (!$hasPsikotes) {
+            abort(403, 'Anda belum memiliki akses ke tes ini.');
+        }
+
         $ongoingTestId = session('test_in_progress');
 
         if ($ongoingTestId && $testResult = TestResult::where('id', $ongoingTestId)->where('user_id', Auth::id())->whereNull('completed_at')->first()) {

--- a/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
+++ b/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
@@ -79,8 +79,10 @@
                                         ->where('status', 'interview')
                                         ->sortByDesc('created_at')
                                         ->first();
-                                        
+
                                     $lastUpdate = optional(optional($lamaran->progressRekrutmen)->last())->created_at;
+
+                                    $showCbtLink = $doneStatuses->contains('psikotes') && !$hasDecision;
                                 @endphp
 
                                 <div class="card border mb-3">
@@ -185,20 +187,27 @@
                                                                 <i class="mdi mdi-video me-1"></i>Join Zoom
                                                             </a>
                                                         @endif
-                                                        @if($latestInterview->catatan)
-                                                            <div class="mt-2"><strong>Catatan:</strong> {{ $latestInterview->catatan }}</div>
-                                                        @endif
-                                                        @if($latestInterview->dokumen_pendukung)
-                                                            <div class="mt-1">
-                                                                <a href="{{ Storage::url($latestInterview->dokumen_pendukung) }}" target="_blank">Dokumen Pendukung</a>
-                                                            </div>
-                                                        @endif
-                                                    </div>
-                                                @endif
-                                            </div>
+                                                    @if($latestInterview->catatan)
+                                                        <div class="mt-2"><strong>Catatan:</strong> {{ $latestInterview->catatan }}</div>
+                                                    @endif
+                                                    @if($latestInterview->dokumen_pendukung)
+                                                        <div class="mt-1">
+                                                            <a href="{{ Storage::url($latestInterview->dokumen_pendukung) }}" target="_blank">Dokumen Pendukung</a>
+                                                        </div>
+                                                    @endif
+                                                </div>
+                                            @endif
+                                            @if($showCbtLink)
+                                                <div class="mt-2">
+                                                    <a href="{{ route('cbt.test') }}" target="_blank" class="btn btn-sm btn-outline-primary">
+                                                        <i class="mdi mdi-pencil me-1"></i>Mulai Psikotes
+                                                    </a>
+                                                </div>
+                                            @endif
+                                        </div>
 
-                                            <!-- Last Update -->
-                                            <div class="col-md-2 text-md-end">
+                                        <!-- Last Update -->
+                                        <div class="col-md-2 text-md-end">
                                                 @if ($lastUpdate)
                                                     <small class="text-muted">
                                                         Update: {{ $lastUpdate->format('d M Y') }}


### PR DESCRIPTION
## Summary
- gate CBT test so only candidates with psychotest status can access
- surface CBT link on application tracker when candidate reaches psychotest stage

## Testing
- `composer test` *(fails: require vendor install)*
- `composer install --no-progress` *(fails: CONNECT tunnel 403 prompting GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d3f03fa48326afcbcd70c9bb7f97