### PR TITLE
Restrict CBT test to psychotest stage and remove navbar link

### DIFF
--- a/app/Livewire/Cbt/Test.php
+++ b/app/Livewire/Cbt/Test.php
@@ -76,7 +76,8 @@ class Test extends Component
         if ($kandidat) {
             $hasPsikotes = $kandidat->lamarLowongans()
                 ->whereHas('progressRekrutmen', function ($q) {
-                    $q->where('status', 'psikotes');
+                    $q->where('status', 'psikotes')
+                        ->where('is_psikotes', true);
                 })
                 ->exists();
         }

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -251,11 +251,6 @@
                                 </li>
                             </ul>
                         </li>
-                        @role('kandidat')
-                        <li class="has-submenu parent-menu-item">
-                            <a href="{{ route('cbt.test') }}">Tes CBT</a>
-                        </li>
-                        @endrole
                         @role('officer')
                         <li class="has-submenu parent-menu-item">
                             <a href="{{ route('kandidat.index') }}">Kandidat</a>


### PR DESCRIPTION
## Summary
- Require candidates to have psychotest progress before accessing CBT
- Remove CBT test link from the main navigation

## Testing
- `composer test` *(fails: Failed to open vendor/autoload.php)*
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a28410c7188326a6f1545eba9c65b2