### PR TITLE
Hide Zoom link when proceeding to psychotest stage

### DIFF
--- a/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
+++ b/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
@@ -82,7 +82,7 @@
 
                                     $lastUpdate = optional(optional($lamaran->progressRekrutmen)->last())->created_at;
 
-                                    $showCbtLink = $doneStatuses->contains('psikotes') && !$hasDecision;
+                                    $showCbtLink = ($activeStep === 'psikotes' || $doneStatuses->contains('psikotes')) && !$hasDecision;
                                 @endphp
 
                                 <div class="card border mb-3">
@@ -181,7 +181,7 @@
                                                         @if($latestInterview->officer)
                                                             <div class="small text-muted">Interviewer: {{ $latestInterview->officer->name }}</div>
                                                         @endif
-                                                        @if($latestInterview->link_zoom)
+                                                        @if($latestInterview->link_zoom && $activeStep !== 'psikotes' && !$doneStatuses->contains('psikotes'))
                                                             <a href="{{ $latestInterview->link_zoom }}" target="_blank" rel="noopener"
                                                                class="btn btn-sm btn-primary mt-1">
                                                                 <i class="mdi mdi-video me-1"></i>Join Zoom


### PR DESCRIPTION
## Summary
- Hide interview Zoom link once candidate enters psychotest stage
- Show psychotest button when candidate is scheduled for or has psychotest progress

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/jobportal/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a285bf2cc4832686c9b1cc5bf2e214