### PR TITLE
Add officer position middleware and role-based routes

### DIFF
--- a/app/Http/Middleware/PositionMiddleware.php
+++ b/app/Http/Middleware/PositionMiddleware.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class PositionMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string[]  ...$positions
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next, ...$positions)
+    {
+        if (!Auth::check()) {
+            return redirect('login');
+        }
+
+        $user = $request->user();
+
+        if (!$user->hasRole('officer') || !$user->officer) {
+            return redirect()->route('dashboard');
+        }
+
+        $userPosition = strtolower($user->officer->jabatan);
+        $positions = array_map(fn($p) => strtolower(trim($p)), $positions);
+
+        if (!in_array($userPosition, $positions)) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,6 +11,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\Kandidat;
+use App\Models\Officer;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -78,7 +79,12 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->hasRole('officer') &&
                 $this->officer &&
-                $this->officer->jabatan === $position;
+                strcasecmp($this->officer->jabatan, $position) === 0;
+    }
+
+    public function officer()
+    {
+        return $this->hasOne(Officer::class, 'user_id');
     }
 
     public function kandidat()

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\RoleMiddleware;
+use App\Http\Middleware\PositionMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -21,6 +22,7 @@ return Application::configure(basePath: dirname(__DIR__))
         // Register route middleware
         $middleware->alias([
             'role' => RoleMiddleware::class,
+            'position' => PositionMiddleware::class,
             // Other middleware aliases...
         ]);
     })

--- a/database/factories/OfficerFactory.php
+++ b/database/factories/OfficerFactory.php
@@ -17,7 +17,7 @@ class OfficerFactory extends Factory
     public function definition(): array
     {
         $locations = ['Jakarta', 'Bandung', 'Surabaya', 'Medan', 'Yogyakarta', 'Bali'];
-        $positions = ['Manager', 'Coordinator', 'Recruiter'];
+        $positions = ['Manager', 'HRGA Coordinator Area', 'Recruiter'];
         return [
             'user_id' => function () {
                 // First, create a user if needed

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,22 +12,61 @@ Route::middleware([
     'verified',
     'role:officer', // Ensure the user has the 'officer' role
 ])->group(function () {
-    Route::get('/officers', App\Livewire\Officer\Index::class)->name('officers.index');
-    Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)->name('kategori-lowongan.Index');
-    Route::get('/lowongan', App\Livewire\Lowongan\Index::class)->name('lowongan.index');
-    Route::get('/lowongan/create', App\Livewire\Lowongan\Create::class)->name('lowongan.create');
-    Route::get('/lowongan/{id}/edit', App\Livewire\Lowongan\Edit::class)->name('lowongan.edit');
-    Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)->name('recruitment.progress');
-    Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)->name('bank-soal.index');
-    Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)->name('kategori-soal.index');
-    Route::get('/Lowongan/Index', App\Livewire\Lowongan\Index::class)->name('Lowongan.Index');
-    Route::get('/Lowongan/Create', App\Livewire\Lowongan\Create::class)->name('Lowongan.Create');
-    Route::get('/test-results', App\Livewire\Officer\TestResults\Index::class)->name('test-results.index');
-    Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)->name('kandidat.index');
+    Route::get('/officers', App\Livewire\Officer\Index::class)
+        ->middleware('position:HRGA Coordinator Area')
+        ->name('officers.index');
+
+    Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('kategori-lowongan.Index');
+
+    Route::get('/lowongan', App\Livewire\Lowongan\Index::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area,Manager')
+        ->name('lowongan.index');
+
+    Route::get('/lowongan/create', App\Livewire\Lowongan\Create::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('lowongan.create');
+
+    Route::get('/lowongan/{id}/edit', App\Livewire\Lowongan\Edit::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('lowongan.edit');
+
+    Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)
+        ->middleware('position:HRGA Coordinator Area,Manager')
+        ->name('recruitment.progress');
+
+    Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('bank-soal.index');
+
+    Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('kategori-soal.index');
+
+    Route::get('/Lowongan/Index', App\Livewire\Lowongan\Index::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area,Manager')
+        ->name('Lowongan.Index');
+
+    Route::get('/Lowongan/Create', App\Livewire\Lowongan\Create::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('Lowongan.Create');
+
+    Route::get('/test-results', App\Livewire\Officer\TestResults\Index::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('test-results.index');
+
+    Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('kandidat.index');
+
     Route::get('/lamaran-lowongan', App\Livewire\Officer\LamaranLowongan\Index::class)
-    ->name('lamaran-lowongan.index');
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('lamaran-lowongan.index');
+
     Route::get('/jadwal-interview', App\Livewire\Officer\InterviewSchedule\Index::class)
-    ->name('jadwal-interview.index');
+        ->middleware('position:Recruiter,HRGA Coordinator Area')
+        ->name('jadwal-interview.index');
 
 });
 


### PR DESCRIPTION
## Summary
- Add `PositionMiddleware` to gate officer features by jabatan
- Extend User model with officer relation and case-insensitive `hasPosition`
- Register new middleware and wire recruiter/HRGA/manager access in routes
- Update officer factory positions to include HRGA Coordinator Area

## Testing
- `php -d detect_unicode=0 artisan test` *(fails: vendor/autoload.php not found)*
- `composer install` *(fails: GitHub 403, could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c13c0a288326959560916ba68d1e