### PR TITLE
Integrate Spatie roles for officers and seed data

### DIFF
--- a/app/Http/Middleware/PositionMiddleware.php
+++ b/app/Http/Middleware/PositionMiddleware.php
@@ -24,7 +24,7 @@ class PositionMiddleware
 
         $user = $request->user();
 
-        if (!$user->hasRole('officer') || !$user->officer) {
+        if (!$user->hasSystemRole('officer') || !$user->officer) {
             return redirect()->route('dashboard');
         }
 

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -26,11 +26,11 @@ class RoleMiddleware
         $user = $request->user();
 
         // Jika user tidak memiliki role yang diperlukan
-        if (!$user->hasRole($role)) {
+        if (!$user->hasSystemRole($role)) {
             // Redirect berdasarkan role yang dimiliki user
-            if ($user->hasRole('officer')) {
+            if ($user->hasSystemRole('officer')) {
                 return redirect()->route('officers.index');
-            } elseif ($user->hasRole('kandidat')) {
+            } elseif ($user->hasSystemRole('kandidat')) {
                 return redirect()->route('dashboard');
             } else {
                 // User terautentikasi tapi tidak memiliki role yang valid

--- a/app/Http/Responses/LoginResponse.php
+++ b/app/Http/Responses/LoginResponse.php
@@ -19,8 +19,7 @@ class LoginResponse implements LoginResponseContract
         $user = Auth::user();
 
         // Cek jika pengguna memiliki peran 'officer'
-        // Method hasRole() biasanya dari paket Spatie/laravel-permission
-        if ($user->hasRole('officer')) {
+        if ($user->hasSystemRole('officer')) {
             return redirect()->route('officers.index');
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\Kandidat;
 use App\Models\Officer;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -22,6 +23,7 @@ class User extends Authenticatable implements MustVerifyEmail
     use HasProfilePhoto;
     use Notifiable;
     use TwoFactorAuthenticatable;
+    use HasRoles;
 
     /**
      * The attributes that are mass assignable.
@@ -69,15 +71,17 @@ class User extends Authenticatable implements MustVerifyEmail
         ];
     }
 
-    public function hasRole($role)
+    /**
+     * Check application-level role stored in the `role` column.
+     */
+    public function hasSystemRole($role)
     {
-        // Example implementation - adjust based on your actual role structure
         return $this->role === $role;
     }
 
     public function hasPosition($position)
     {
-        return $this->hasRole('officer') &&
+        return $this->hasSystemRole('officer') &&
                 $this->officer &&
                 strcasecmp($this->officer->jabatan, $position) === 0;
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,12 +15,15 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
+        $this->call([RolePermissionSeeder::class]);
+
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
-            'role' => 'officer', // Assuming the role is set to 'officer'
+            'role' => 'officer',
         ]);
+
         $this->call([
             OfficerSeeder::class,
             KandidatSeeder::class,

--- a/database/seeders/OfficerSeeder.php
+++ b/database/seeders/OfficerSeeder.php
@@ -6,6 +6,7 @@ use App\Models\Officer;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
+
 class OfficerSeeder extends Seeder
 {
     /**
@@ -13,8 +14,19 @@ class OfficerSeeder extends Seeder
      */
     public function run(): void
     {
-        Officer::factory()->count(5)->create([
-            'atasan_id' => null, // Set to null for top-level officers
-        ]);
+        $roles = [
+            'Recruiter' => 'Recruiter',
+            'HRGA Coordinator Area' => 'HRGA Coordinator Area',
+            'Manager' => 'Manager',
+        ];
+
+        foreach ($roles as $roleName => $jabatan) {
+            $officer = Officer::factory()->create([
+                'atasan_id' => null,
+                'jabatan' => $jabatan,
+            ]);
+
+            $officer->user->assignRole($roleName);
+        }
     }
 }

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class RolePermissionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $permissions = [
+            'create lowongan',
+            'update lowongan',
+            'delete lowongan',
+            'view applicant',
+            'download applicant',
+            'view test result',
+            'update progress rekrutmen',
+            'review progress rekrutmen',
+            'share progress rekrutmen',
+            'review lowongan',
+            'share lowongan',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::firstOrCreate(['name' => $permission]);
+        }
+
+        $recruiter = Role::firstOrCreate(['name' => 'Recruiter']);
+        $recruiter->givePermissionTo([
+            'create lowongan',
+            'update lowongan',
+            'delete lowongan',
+            'view applicant',
+            'download applicant',
+            'view test result',
+        ]);
+
+        $hrga = Role::firstOrCreate(['name' => 'HRGA Coordinator Area']);
+        $hrga->givePermissionTo([
+            'create lowongan',
+            'update lowongan',
+            'delete lowongan',
+            'view applicant',
+            'download applicant',
+            'view test result',
+            'update progress rekrutmen',
+        ]);
+
+        $manager = Role::firstOrCreate(['name' => 'Manager']);
+        $manager->givePermissionTo([
+            'review progress rekrutmen',
+            'share progress rekrutmen',
+            'review lowongan',
+            'share lowongan',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add Spatie HasRoles trait and system role helper on `User`
- Seed roles and permissions for Recruiter, HRGA Coordinator Area, and Manager
- Update middleware, login response, and seeders to use system roles and assign Spatie roles

## Testing
- `php -l app/Models/User.php app/Http/Responses/LoginResponse.php app/Http/Middleware/RoleMiddleware.php app/Http/Middleware/PositionMiddleware.php database/seeders/DatabaseSeeder.php database/seeders/OfficerSeeder.php database/seeders/RolePermissionSeeder.php`
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d416d904832686d382a1fb2b2219