### PR TITLE
Add candidate name fields during registration

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Fortify;
 
 use App\Models\User;
+use App\Models\Kandidat;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Session;
@@ -35,16 +36,27 @@ class CreateNewUser implements CreatesNewUsers
         }
 
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
+            'nama_depan' => ['required', 'string', 'max:255'],
+            'nama_belakang' => ['nullable', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => $this->passwordRules(),
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
         ])->validate();
 
-        return User::create([
-            'name' => $input['name'],
+        $user = User::create([
+            'name' => trim($input['nama_depan'].' '.($input['nama_belakang'] ?? '')),
             'email' => $input['email'],
             'password' => Hash::make($input['password']),
         ]);
+
+        Kandidat::create([
+            'user_id' => $user->id,
+            'nama_depan' => $input['nama_depan'],
+            'nama_belakang' => $input['nama_belakang'] ?? null,
+            'bmi_score' => $testData['bmi']['score'],
+            'blind_score' => $testData['blind']['score'],
+        ]);
+
+        return $user;
     }
 }

--- a/app/Listeners/ProcessGuestTestData.php
+++ b/app/Listeners/ProcessGuestTestData.php
@@ -25,9 +25,15 @@ class ProcessGuestTestData
     {
         if (Session::has('guest_test_data')) {
             $user = $event->user;
-            $kandidat = Kandidat::firstOrCreate(['user_id' => $user->id]);
-
             $testData = Session::get('guest_test_data');
+            $kandidat = Kandidat::firstOrCreate(
+                ['user_id' => $user->id],
+                [
+                    'nama_depan' => $user->name,
+                    'bmi_score' => $testData['bmi']['score'] ?? null,
+                    'blind_score' => $testData['blind']['score'] ?? null,
+                ]
+            );
 
             // Simpan data BMI jika ada di sesi dan belum ada di DB
             if (isset($testData['bmi']) && !$kandidat->bmi_score) {

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -9,9 +9,15 @@
             <h6 class="mb-3 text-uppercase fw-semibold">{{ __('Register your account') }}</h6>
 
             <div class="mb-3">
-                <x-label for="name" value="{{ __('Your Name') }}" />
-                <x-input name="name" id="name" type="text" class="form-control" placeholder="Calvin Carlo" :value="old('name')" required autofocus autocomplete="name" />
-                <x-custom-input-error for="name" />
+                <x-label for="nama_depan" value="{{ __('Nama Depan') }}" />
+                <x-input name="nama_depan" id="nama_depan" type="text" class="form-control" placeholder="Budi" :value="old('nama_depan')" required autofocus autocomplete="given-name" />
+                <x-custom-input-error for="nama_depan" />
+            </div>
+
+            <div class="mb-3">
+                <x-label for="nama_belakang" value="{{ __('Nama Belakang') }}" />
+                <x-input name="nama_belakang" id="nama_belakang" type="text" class="form-control" placeholder="Santoso" :value="old('nama_belakang')" autocomplete="family-name" />
+                <x-custom-input-error for="nama_belakang" />
             </div>
 
             <div class="mb-3">

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -40,7 +40,8 @@ class RegistrationTest extends TestCase
         }
 
         $response = $this->post('/register', [
-            'name' => 'Test User',
+            'nama_depan' => 'Test',
+            'nama_belakang' => 'User',
             'email' => 'test@example.com',
             'password' => 'password',
             'password_confirmation' => 'password',


### PR DESCRIPTION
## Summary
- capture first and last name during user registration
- persist candidate record with names and test scores
- ensure guest test processing creates candidates with a name
- adjust registration feature test for new fields

## Testing
- `composer install` *(fails: Failed to download doctrine/inflector from dist: curl error 56 while downloading https://api.github.com/... CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e74d2b5c8326b1b327dbab84daa6