### PR TITLE
Add Koordinator position to officer creation modal

### DIFF
--- a/resources/views/livewire/officer/create-modal.blade.php
+++ b/resources/views/livewire/officer/create-modal.blade.php
@@ -54,6 +54,9 @@
                                     @foreach($positions ?? [] as $position)
                                         <option value="{{ $position }}">{{ $position }}</option>
                                     @endforeach
+                                    @if (!collect($positions)->contains('Koordinator'))
+                                        <option value="Koordinator">Koordinator</option>
+                                    @endif
                                 </select>
                                 @error('officerData.jabatan') <div class="invalid-feedback">{{ $message }}</div> @enderror
                             </div>


### PR DESCRIPTION
## Summary
- ensure Koordinator can be selected when creating an officer by adding a fallback option to the position dropdown

## Testing
- `composer test` *(fails: require vendor autoload; composer install requested GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fe8d8ea48326842db20f1cb19b42