### PR TITLE
Handle user_create on candidate registration

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -55,6 +55,7 @@ class CreateNewUser implements CreatesNewUsers
             'nama_belakang' => $input['nama_belakang'] ?? null,
             'bmi_score' => $testData['bmi']['score'],
             'blind_score' => $testData['blind']['score'],
+            'user_create' => $user->id,
         ]);
 
         return $user;

--- a/app/Models/Kandidat.php
+++ b/app/Models/Kandidat.php
@@ -40,6 +40,8 @@ class Kandidat extends Model
         'pendidikan',
         'kemampuan_bahasa',
         'kemampuan',
+        'user_create',
+        'user_update',
     ];
 
     protected $casts = [


### PR DESCRIPTION
## Summary
- include user_create when creating Kandidat during registration
- allow Kandidat model to accept user_create and user_update fields

## Testing
- `composer test` *(fails: require(/workspace/jobportal/vendor/autoload.php): Failed to open stream)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a412a39908832682846ce426eecf1c