### PR TITLE
Add country selection to candidate registration

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -39,6 +39,7 @@ class CreateNewUser implements CreatesNewUsers
             'nama_depan' => ['required', 'string', 'max:255'],
             'nama_belakang' => ['nullable', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'negara' => ['required', 'string', 'max:255'],
             'password' => $this->passwordRules(),
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
         ])->validate();
@@ -53,6 +54,7 @@ class CreateNewUser implements CreatesNewUsers
             'user_id' => $user->id,
             'nama_depan' => $input['nama_depan'],
             'nama_belakang' => $input['nama_belakang'] ?? null,
+            'negara' => $input['negara'],
             'bmi_score' => $testData['bmi']['score'],
             'blind_score' => $testData['blind']['score'],
             'user_create' => $user->id,

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -26,6 +26,20 @@
                 <x-custom-input-error for="email" />
             </div>
 
+            @php
+                $countries = ['Indonesia', 'Malaysia', 'Singapore', 'Thailand', 'Philippines'];
+            @endphp
+            <div class="mb-3">
+                <x-label for="negara" value="{{ __('Negara') }}" />
+                <select name="negara" id="negara" class="form-select" required>
+                    <option value="">{{ __('Pilih Negara') }}</option>
+                    @foreach($countries as $country)
+                        <option value="{{ $country }}" @selected(old('negara') === $country)>{{ $country }}</option>
+                    @endforeach
+                </select>
+                <x-custom-input-error for="negara" />
+            </div>
+
             <div class="mb-3">
                 <x-label for="loginpass" value="{{ __('Password') }}" />
                 <x-input name="password" id="loginpass" type="password" class="form-control" placeholder="Password" required autocomplete="new-password" />

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -39,10 +39,16 @@ class RegistrationTest extends TestCase
             $this->markTestSkipped('Registration support is not enabled.');
         }
 
-        $response = $this->post('/register', [
+        $response = $this->withSession([
+            'guest_test_data' => [
+                'bmi' => ['score' => 22, 'kategori' => 'Normal'],
+                'blind' => ['score' => 80],
+            ],
+        ])->post('/register', [
             'nama_depan' => 'Test',
             'nama_belakang' => 'User',
             'email' => 'test@example.com',
+            'negara' => 'Indonesia',
             'password' => 'password',
             'password_confirmation' => 'password',
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),


### PR DESCRIPTION
## Summary
- add country dropdown to registration form
- validate and store country for candidates
- cover registration test with country and session data

## Testing
- `php artisan test --filter=RegistrationTest --stop-on-failure` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install --no-interaction` *(fails: unable to access 'https://github.com/Bacon/BaconQrCode.git': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a41953ce5c8326ad28bc656eafd515