### PR TITLE
Use ResourceBundle for country dropdown

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -27,7 +27,14 @@
             </div>
 
             @php
-                $countries = ['Indonesia', 'Malaysia', 'Singapore', 'Thailand', 'Philippines'];
+                $bundle = \ResourceBundle::create('en', 'ICUDATA-region')['Countries'];
+                $countries = [];
+                foreach ($bundle as $code => $name) {
+                    if (strlen($code) === 2 && ctype_alpha($code)) {
+                        $countries[] = $name;
+                    }
+                }
+                sort($countries);
             @endphp
             <div class="mb-3">
                 <x-label for="negara" value="{{ __('Negara') }}" />


### PR DESCRIPTION
## Summary
- populate registration country dropdown using PHP's ResourceBundle to list worldwide regions

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/jobportal/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a41af25a9c8326881f9629f7df0dd9