### PR TITLE
Add extended kandidat profile fields

### DIFF
--- a/app/Livewire/Profile/UpdateKandidatProfileForm.php
+++ b/app/Livewire/Profile/UpdateKandidatProfileForm.php
@@ -37,6 +37,12 @@ class UpdateKandidatProfileForm extends Component
             // Jika kandidat sudah ada, muat datanya
             $this->state = $this->kandidat->toArray();
 
+            // Pastikan field baru tersedia
+            $this->state['kota'] = $this->state['kota'] ?? '';
+            $this->state['pernah_bekerja'] = $this->state['pernah_bekerja'] ?? '';
+            $this->state['lokasi_bekerja'] = $this->state['lokasi_bekerja'] ?? '';
+            $this->state['sumber_informasi'] = $this->state['sumber_informasi'] ?? '';
+
             // PERBAIKAN: Ubah format tanggal agar sesuai dengan input HTML
             if (isset($this->state['tanggal_lahir'])) {
                 $this->state['tanggal_lahir'] = \Carbon\Carbon::parse($this->state['tanggal_lahir'])->setTimezone(config('app.timezone'))->format('Y-m-d');
@@ -49,6 +55,7 @@ class UpdateKandidatProfileForm extends Component
                 'no_telpon' => '',
                 'no_telpon_alternatif' => '',
                 'alamat' => '',
+                'kota' => '',
                 'kode_pos' => '',
                 'negara' => 'Indonesia',
                 'no_ktp' => '',
@@ -62,6 +69,9 @@ class UpdateKandidatProfileForm extends Component
                 'pengalaman_kerja' => '',
                 'kemampuan_bahasa' => '',
                 'kemampuan' => '',
+                'pernah_bekerja' => '',
+                'lokasi_bekerja' => '',
+                'sumber_informasi' => '',
             ];
         }
     }
@@ -81,6 +91,7 @@ class UpdateKandidatProfileForm extends Component
             'state.no_telpon' => ['required', 'string', 'max:20'],
             'state.no_telpon_alternatif' => ['nullable', 'string', 'max:20'],
             'state.alamat' => ['required', 'string'],
+            'state.kota' => ['required', 'string', 'max:100'],
             'state.kode_pos' => ['required', 'string', 'max:10'],
             'state.negara' => ['required', 'string', 'max:100'],
             'state.no_ktp' => ['required', 'string', 'max:20', Rule::unique('kandidats', 'no_ktp')->ignore($user->kandidat->id ?? null)],
@@ -94,6 +105,9 @@ class UpdateKandidatProfileForm extends Component
             'state.pengalaman_kerja' => ['nullable', 'string'],
             'state.kemampuan_bahasa' => ['nullable', 'string'],
             'state.kemampuan' => ['nullable', 'string'],
+            'state.pernah_bekerja' => ['nullable', 'string', 'max:100'],
+            'state.lokasi_bekerja' => ['nullable', 'string', 'max:255'],
+            'state.sumber_informasi' => ['nullable', 'string', 'max:255'],
         ]);
 
         // Gunakan updateOrCreate untuk membuat profil jika belum ada, atau memperbarui jika sudah ada

--- a/app/Models/Kandidat.php
+++ b/app/Models/Kandidat.php
@@ -24,6 +24,7 @@ class Kandidat extends Model
         'nama_belakang',
         'no_telpon',
         'alamat',
+        'kota',
         'kode_pos',
         'negara',
         'no_ktp',
@@ -40,6 +41,9 @@ class Kandidat extends Model
         'pendidikan',
         'kemampuan_bahasa',
         'kemampuan',
+        'pernah_bekerja',
+        'lokasi_bekerja',
+        'sumber_informasi',
         'user_create',
         'user_update',
     ];

--- a/database/factories/KandidatFactory.php
+++ b/database/factories/KandidatFactory.php
@@ -28,6 +28,7 @@ class KandidatFactory extends Factory
             'nama_belakang' => $this->faker->lastName(),
             'no_telpon' => $this->faker->phoneNumber(),
             'alamat' => $this->faker->address(),
+            'kota' => $this->faker->city(),
             'kode_pos' => $this->faker->postcode(),
             'negara' => $this->faker->country(),
             'no_ktp' => $this->faker->unique()->numerify('##########'),
@@ -44,6 +45,9 @@ class KandidatFactory extends Factory
             'pendidikan' => $this->faker->randomElement(['SD', 'SMP', 'SMA', 'D3', 'S1', 'S2']),
             'kemampuan_bahasa' => $this->faker->text(),
             'kemampuan' => $this->faker->text(),
+            'pernah_bekerja' => $this->faker->randomElement(['Ya', 'Tidak']),
+            'lokasi_bekerja' => $this->faker->city(),
+            'sumber_informasi' => $this->faker->sentence(),
             'user_create' => 1, // Assuming user with ID 1 is the creator
             'user_update' => 1, // Assuming user with ID 1 is the updater
             'created_at' => now(),

--- a/database/migrations/2025_07_06_170000_add_columns_to_kandidats_table.php
+++ b/database/migrations/2025_07_06_170000_add_columns_to_kandidats_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('kandidats', function (Blueprint $table) {
+            $table->string('kota')->nullable()->after('alamat');
+            $table->string('pernah_bekerja')->nullable()->after('kemampuan');
+            $table->string('lokasi_bekerja')->nullable()->after('pernah_bekerja');
+            $table->string('sumber_informasi')->nullable()->after('lokasi_bekerja');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('kandidats', function (Blueprint $table) {
+            $table->dropColumn(['kota', 'pernah_bekerja', 'lokasi_bekerja', 'sumber_informasi']);
+        });
+    }
+};

--- a/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
+++ b/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
@@ -76,7 +76,7 @@
                                 <hr class="my-4">
                             @endif
                             {{-- Data Pribadi Section --}}
-                            <div class="row">
+                            <div class="row" id="profile-info">
                                 <div class="col-12 mb-4">
                                     <h6 class="fw-bold text-primary border-bottom pb-2">
                                         <i class="mdi mdi-account-outline me-2"></i>Data Pribadi
@@ -164,18 +164,27 @@
                                     @enderror
                                 </div>
 
-                                <div class="col-md-6 mb-3">
+                                <div class="col-md-4 mb-3">
+                                    <label for="kota" class="form-label">{{ __('Kota') }} <span class="text-danger">*</span></label>
+                                    <input id="kota" type="text" class="form-control @error('state.kota') is-invalid @enderror"
+                                        wire:model.defer="state.kota" placeholder="Masukkan kota">
+                                    @error('state.kota')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-4 mb-3">
                                     <label for="kode_pos" class="form-label">{{ __('Kode Pos') }} <span class="text-danger">*</span></label>
-                                    <input id="kode_pos" type="text" class="form-control @error('state.kode_pos') is-invalid @enderror" 
+                                    <input id="kode_pos" type="text" class="form-control @error('state.kode_pos') is-invalid @enderror"
                                         wire:model.defer="state.kode_pos" placeholder="Masukkan kode pos">
                                     @error('state.kode_pos')
                                         <div class="invalid-feedback">{{ $message }}</div>
                                     @enderror
                                 </div>
-                                
-                                <div class="col-md-6 mb-3">
+
+                                <div class="col-md-4 mb-3">
                                     <label for="negara" class="form-label">{{ __('Negara') }} <span class="text-danger">*</span></label>
-                                    <input id="negara" type="text" class="form-control @error('state.negara') is-invalid @enderror" 
+                                    <input id="negara" type="text" class="form-control @error('state.negara') is-invalid @enderror"
                                         wire:model.defer="state.negara" placeholder="Masukkan negara" value="Indonesia">
                                     @error('state.negara')
                                         <div class="invalid-feedback">{{ $message }}</div>
@@ -235,7 +244,7 @@
                                     </h6>
                                 </div>
 
-                                <div class="col-md-6 mb-3">
+                                <div class="col-md-6 mb-3" id="education">
                                     <label for="pendidikan" class="form-label">{{ __('Pendidikan Terakhir') }} <span class="text-danger">*</span></label>
                                     <select id="pendidikan" wire:model.defer="state.pendidikan" class="form-select @error('state.pendidikan') is-invalid @enderror">
                                         <option value="">Pilih...</option>
@@ -255,7 +264,7 @@
                                     @enderror
                                 </div>
                                 
-                                <div class="col-12 mb-3">
+                                <div class="col-12 mb-3" id="work-experience">
                                     <label for="pengalaman_kerja" class="form-label">{{ __('Pengalaman Kerja (Opsional)') }}</label>
                                     <textarea id="pengalaman_kerja" class="form-control @error('state.pengalaman_kerja') is-invalid @enderror" 
                                         wire:model.defer="state.pengalaman_kerja" rows="4" 
@@ -266,7 +275,7 @@
                                     @enderror
                                 </div>
 
-                                <div class="col-12 mb-3">
+                                <div class="col-12 mb-3" id="language">
                                     <label for="kemampuan_bahasa" class="form-label">{{ __('Kemampuan Bahasa (Opsional)') }}</label>
                                     <textarea id="kemampuan_bahasa" class="form-control @error('state.kemampuan_bahasa') is-invalid @enderror" 
                                         wire:model.defer="state.kemampuan_bahasa" rows="2" 
@@ -279,11 +288,53 @@
                                 
                                 <div class="col-12 mb-3">
                                     <label for="kemampuan" class="form-label">{{ __('Keahlian (Opsional)') }}</label>
-                                    <textarea id="kemampuan" class="form-control @error('state.kemampuan') is-invalid @enderror" 
-                                        wire:model.defer="state.kemampuan" rows="4" 
+                                    <textarea id="kemampuan" class="form-control @error('state.kemampuan') is-invalid @enderror"
+                                        wire:model.defer="state.kemampuan" rows="4"
                                         placeholder="Sebutkan keahlian yang Anda miliki, seperti bahasa pemrograman, software, sertifikasi, dll"></textarea>
                                     <small class="text-muted">Contoh: JavaScript, PHP, Laravel, MySQL, Adobe Photoshop, Google Analytics</small>
                                     @error('state.kemampuan')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            {{-- Divider --}}
+                            <hr class="my-4">
+
+                            {{-- Informasi Spesifik Section --}}
+                            <div class="row" id="specific-info">
+                                <div class="col-12 mb-4">
+                                    <h6 class="fw-bold text-primary border-bottom pb-2">
+                                        <i class="mdi mdi-information-outline me-2"></i>Informasi Spesifik
+                                    </h6>
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="pernah_bekerja" class="form-label">{{ __('Pernah bekerja di perusahaan ini?') }}</label>
+                                    <select id="pernah_bekerja" wire:model.defer="state.pernah_bekerja" class="form-select @error('state.pernah_bekerja') is-invalid @enderror">
+                                        <option value="">Pilih...</option>
+                                        <option value="Ya">Ya</option>
+                                        <option value="Tidak">Tidak</option>
+                                    </select>
+                                    @error('state.pernah_bekerja')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="lokasi_bekerja" class="form-label">{{ __('Lokasi bekerja sebelumnya') }}</label>
+                                    <input id="lokasi_bekerja" type="text" class="form-control @error('state.lokasi_bekerja') is-invalid @enderror"
+                                        wire:model.defer="state.lokasi_bekerja" placeholder="Masukkan lokasi">
+                                    @error('state.lokasi_bekerja')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="sumber_informasi" class="form-label">{{ __('Sumber informasi pekerjaan ini') }}</label>
+                                    <input id="sumber_informasi" type="text" class="form-control @error('state.sumber_informasi') is-invalid @enderror"
+                                        wire:model.defer="state.sumber_informasi" placeholder="Masukkan sumber informasi">
+                                    @error('state.sumber_informasi')
                                         <div class="invalid-feedback">{{ $message }}</div>
                                     @enderror
                                 </div>


### PR DESCRIPTION
## Summary
- collect additional kandidat info including city and employment details
- allow editing specific profile information via new form sections

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: GitHub token required)*

------
https://chatgpt.com/codex/tasks/task_e_68a4242f7cf08326b60847e616d0c7d6