### PR TITLE
Add middle name and dynamic profile sections

### DIFF
--- a/app/Livewire/Profile/UpdateKandidatProfileForm.php
+++ b/app/Livewire/Profile/UpdateKandidatProfileForm.php
@@ -38,10 +38,22 @@ class UpdateKandidatProfileForm extends Component
             $this->state = $this->kandidat->toArray();
 
             // Pastikan field baru tersedia
+            $this->state['nama_tengah'] = $this->state['nama_tengah'] ?? '';
             $this->state['kota'] = $this->state['kota'] ?? '';
             $this->state['pernah_bekerja'] = $this->state['pernah_bekerja'] ?? '';
             $this->state['lokasi_bekerja'] = $this->state['lokasi_bekerja'] ?? '';
             $this->state['sumber_informasi'] = $this->state['sumber_informasi'] ?? '';
+
+            // Decode JSON fields to arrays
+            $this->state['pengalaman_kerja'] = $this->kandidat->pengalaman_kerja ? json_decode($this->kandidat->pengalaman_kerja, true) : [
+                ['tanggal_mulai' => '', 'tanggal_selesai' => '', 'nama_perusahaan' => '', 'keterangan_bisnis' => '', 'jabatan' => '', 'alasan_keluar' => ''],
+            ];
+            $this->state['pendidikan'] = $this->kandidat->pendidikan ? json_decode($this->kandidat->pendidikan, true) : [
+                ['tanggal_mulai' => '', 'tanggal_selesai' => '', 'nama_pendidikan' => '', 'jurusan' => '', 'tingkat' => '', 'pendidikan_tertinggi' => 'Tidak'],
+            ];
+            $this->state['kemampuan_bahasa'] = $this->kandidat->kemampuan_bahasa ? json_decode($this->kandidat->kemampuan_bahasa, true) : [
+                ['bahasa' => '', 'bicara' => '', 'membaca' => '', 'menulis' => ''],
+            ];
 
             // PERBAIKAN: Ubah format tanggal agar sesuai dengan input HTML
             if (isset($this->state['tanggal_lahir'])) {
@@ -51,6 +63,7 @@ class UpdateKandidatProfileForm extends Component
             // Jika kandidat belum ada, siapkan state dengan data kosong
             $this->state = [
                 'nama_depan' => '',
+                'nama_tengah' => '',
                 'nama_belakang' => '',
                 'no_telpon' => '',
                 'no_telpon_alternatif' => '',
@@ -65,15 +78,57 @@ class UpdateKandidatProfileForm extends Component
                 'jenis_kelamin' => '',
                 'status_perkawinan' => '',
                 'agama' => '',
-                'pendidikan' => '',
-                'pengalaman_kerja' => '',
-                'kemampuan_bahasa' => '',
+                'pengalaman_kerja' => [
+                    ['tanggal_mulai' => '', 'tanggal_selesai' => '', 'nama_perusahaan' => '', 'keterangan_bisnis' => '', 'jabatan' => '', 'alasan_keluar' => ''],
+                ],
+                'pendidikan' => [
+                    ['tanggal_mulai' => '', 'tanggal_selesai' => '', 'nama_pendidikan' => '', 'jurusan' => '', 'tingkat' => '', 'pendidikan_tertinggi' => 'Tidak'],
+                ],
+                'kemampuan_bahasa' => [
+                    ['bahasa' => '', 'bicara' => '', 'membaca' => '', 'menulis' => ''],
+                ],
                 'kemampuan' => '',
                 'pernah_bekerja' => '',
                 'lokasi_bekerja' => '',
                 'sumber_informasi' => '',
             ];
         }
+    }
+
+    /**
+     * Add a new empty work experience entry.
+     */
+    public function addWorkExperience()
+    {
+        $this->state['pengalaman_kerja'][] = ['tanggal_mulai' => '', 'tanggal_selesai' => '', 'nama_perusahaan' => '', 'keterangan_bisnis' => '', 'jabatan' => '', 'alasan_keluar' => ''];
+    }
+
+    public function removeWorkExperience($index)
+    {
+        unset($this->state['pengalaman_kerja'][$index]);
+        $this->state['pengalaman_kerja'] = array_values($this->state['pengalaman_kerja']);
+    }
+
+    public function addEducation()
+    {
+        $this->state['pendidikan'][] = ['tanggal_mulai' => '', 'tanggal_selesai' => '', 'nama_pendidikan' => '', 'jurusan' => '', 'tingkat' => '', 'pendidikan_tertinggi' => 'Tidak'];
+    }
+
+    public function removeEducation($index)
+    {
+        unset($this->state['pendidikan'][$index]);
+        $this->state['pendidikan'] = array_values($this->state['pendidikan']);
+    }
+
+    public function addLanguage()
+    {
+        $this->state['kemampuan_bahasa'][] = ['bahasa' => '', 'bicara' => '', 'membaca' => '', 'menulis' => ''];
+    }
+
+    public function removeLanguage($index)
+    {
+        unset($this->state['kemampuan_bahasa'][$index]);
+        $this->state['kemampuan_bahasa'] = array_values($this->state['kemampuan_bahasa']);
     }
 
     /**
@@ -87,6 +142,7 @@ class UpdateKandidatProfileForm extends Component
 
         $validatedData = $this->validate([
             'state.nama_depan' => ['required', 'string', 'max:255'],
+            'state.nama_tengah' => ['nullable', 'string', 'max:255'],
             'state.nama_belakang' => ['required', 'string', 'max:255'],
             'state.no_telpon' => ['required', 'string', 'max:20'],
             'state.no_telpon_alternatif' => ['nullable', 'string', 'max:20'],
@@ -101,19 +157,40 @@ class UpdateKandidatProfileForm extends Component
             'state.jenis_kelamin' => ['required', 'in:L,P'],
             'state.status_perkawinan' => ['required', 'string', 'max:50'],
             'state.agama' => ['required', 'string', 'max:50'],
-            'state.pendidikan' => ['required', 'string'],
-            'state.pengalaman_kerja' => ['nullable', 'string'],
-            'state.kemampuan_bahasa' => ['nullable', 'string'],
+            'state.pengalaman_kerja' => ['nullable', 'array'],
+            'state.pengalaman_kerja.*.tanggal_mulai' => ['nullable', 'date'],
+            'state.pengalaman_kerja.*.tanggal_selesai' => ['nullable', 'date'],
+            'state.pengalaman_kerja.*.nama_perusahaan' => ['nullable', 'string', 'max:255'],
+            'state.pengalaman_kerja.*.keterangan_bisnis' => ['nullable', 'string', 'max:255'],
+            'state.pengalaman_kerja.*.jabatan' => ['nullable', 'string', 'max:255'],
+            'state.pengalaman_kerja.*.alasan_keluar' => ['nullable', 'string', 'max:255'],
+            'state.pendidikan' => ['nullable', 'array'],
+            'state.pendidikan.*.tanggal_mulai' => ['nullable', 'date'],
+            'state.pendidikan.*.tanggal_selesai' => ['nullable', 'date'],
+            'state.pendidikan.*.nama_pendidikan' => ['nullable', 'string', 'max:255'],
+            'state.pendidikan.*.jurusan' => ['nullable', 'string', 'max:255'],
+            'state.pendidikan.*.tingkat' => ['nullable', 'string', 'max:100'],
+            'state.pendidikan.*.pendidikan_tertinggi' => ['nullable', 'string', 'max:100'],
+            'state.kemampuan_bahasa' => ['nullable', 'array'],
+            'state.kemampuan_bahasa.*.bahasa' => ['nullable', 'string', 'max:100'],
+            'state.kemampuan_bahasa.*.bicara' => ['nullable', 'string', 'max:100'],
+            'state.kemampuan_bahasa.*.membaca' => ['nullable', 'string', 'max:100'],
+            'state.kemampuan_bahasa.*.menulis' => ['nullable', 'string', 'max:100'],
             'state.kemampuan' => ['nullable', 'string'],
             'state.pernah_bekerja' => ['nullable', 'string', 'max:100'],
             'state.lokasi_bekerja' => ['nullable', 'string', 'max:255'],
             'state.sumber_informasi' => ['nullable', 'string', 'max:255'],
         ]);
 
+        $state = $validatedData['state'];
+        $state['pengalaman_kerja'] = json_encode($state['pengalaman_kerja']);
+        $state['pendidikan'] = json_encode($state['pendidikan']);
+        $state['kemampuan_bahasa'] = json_encode($state['kemampuan_bahasa']);
+
         // Gunakan updateOrCreate untuk membuat profil jika belum ada, atau memperbarui jika sudah ada
         Kandidat::updateOrCreate(
             ['user_id' => $user->id],
-            $validatedData['state']
+            $state
         );
 
         // Beri feedback ke pengguna

--- a/app/Models/Kandidat.php
+++ b/app/Models/Kandidat.php
@@ -21,6 +21,7 @@ class Kandidat extends Model
     protected $fillable = [
         'user_id',
         'nama_depan',
+        'nama_tengah',
         'nama_belakang',
         'no_telpon',
         'alamat',
@@ -77,7 +78,7 @@ class Kandidat extends Model
      */
     public function getFullNameAttribute()
     {
-        return trim("{$this->nama_depan} {$this->nama_belakang}");
+        return trim("{$this->nama_depan} {$this->nama_tengah} {$this->nama_belakang}");
     }
 
     /**

--- a/database/migrations/2025_07_06_171500_add_nama_tengah_to_kandidats_table.php
+++ b/database/migrations/2025_07_06_171500_add_nama_tengah_to_kandidats_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('kandidats', function (Blueprint $table) {
+            $table->string('nama_tengah')->nullable()->after('nama_depan');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('kandidats', function (Blueprint $table) {
+            $table->dropColumn('nama_tengah');
+        });
+    }
+};

--- a/resources/views/livewire/profile/show-profile.blade.php
+++ b/resources/views/livewire/profile/show-profile.blade.php
@@ -54,6 +54,10 @@
                                         <p class="fw-medium">{{ $kandidat->nama_depan }}</p>
                                     </div>
                                     <div class="col-md-6 mb-3">
+                                        <h6 class="text-muted mb-0">Nama Tengah</h6>
+                                        <p class="fw-medium">{{ $kandidat->nama_tengah ?? '-' }}</p>
+                                    </div>
+                                    <div class="col-md-6 mb-3">
                                         <h6 class="text-muted mb-0">Nama Belakang</h6>
                                         <p class="fw-medium">{{ $kandidat->nama_belakang }}</p>
                                     </div>

--- a/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
+++ b/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
@@ -83,18 +83,27 @@
                                     </h6>
                                 </div>
                                 
-                                <div class="col-md-6 mb-3">
+                                <div class="col-md-4 mb-3">
                                     <label for="nama_depan" class="form-label">{{ __('Nama Depan') }} <span class="text-danger">*</span></label>
-                                    <input id="nama_depan" type="text" class="form-control @error('state.nama_depan') is-invalid @enderror" 
+                                    <input id="nama_depan" type="text" class="form-control @error('state.nama_depan') is-invalid @enderror"
                                         wire:model.defer="state.nama_depan" autocomplete="given-name" placeholder="Masukkan nama depan">
                                     @error('state.nama_depan')
                                         <div class="invalid-feedback">{{ $message }}</div>
                                     @enderror
                                 </div>
 
-                                <div class="col-md-6 mb-3">
+                                <div class="col-md-4 mb-3">
+                                    <label for="nama_tengah" class="form-label">{{ __('Nama Tengah') }}</label>
+                                    <input id="nama_tengah" type="text" class="form-control @error('state.nama_tengah') is-invalid @enderror"
+                                        wire:model.defer="state.nama_tengah" autocomplete="additional-name" placeholder="Masukkan nama tengah (jika ada)">
+                                    @error('state.nama_tengah')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-4 mb-3">
                                     <label for="nama_belakang" class="form-label">{{ __('Nama Belakang') }} <span class="text-danger">*</span></label>
-                                    <input id="nama_belakang" type="text" class="form-control @error('state.nama_belakang') is-invalid @enderror" 
+                                    <input id="nama_belakang" type="text" class="form-control @error('state.nama_belakang') is-invalid @enderror"
                                         wire:model.defer="state.nama_belakang" autocomplete="family-name" placeholder="Masukkan nama belakang">
                                     @error('state.nama_belakang')
                                         <div class="invalid-feedback">{{ $message }}</div>
@@ -244,46 +253,113 @@
                                     </h6>
                                 </div>
 
-                                <div class="col-md-6 mb-3" id="education">
-                                    <label for="pendidikan" class="form-label">{{ __('Pendidikan Terakhir') }} <span class="text-danger">*</span></label>
-                                    <select id="pendidikan" wire:model.defer="state.pendidikan" class="form-select @error('state.pendidikan') is-invalid @enderror">
-                                        <option value="">Pilih...</option>
-                                        <option value="SD">SD</option>
-                                        <option value="SMP">SMP</option>
-                                        <option value="SMA/SMK">SMA/SMK</option>
-                                        <option value="D1">D1</option>
-                                        <option value="D2">D2</option>
-                                        <option value="D3">D3</option>
-                                        <option value="D4">D4</option>
-                                        <option value="S1">S1</option>
-                                        <option value="S2">S2</option>
-                                        <option value="S3">S3</option>
-                                    </select>
-                                    @error('state.pendidikan')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
-                                </div>
-                                
                                 <div class="col-12 mb-3" id="work-experience">
-                                    <label for="pengalaman_kerja" class="form-label">{{ __('Pengalaman Kerja (Opsional)') }}</label>
-                                    <textarea id="pengalaman_kerja" class="form-control @error('state.pengalaman_kerja') is-invalid @enderror" 
-                                        wire:model.defer="state.pengalaman_kerja" rows="4" 
-                                        placeholder="Deskripsikan pengalaman kerja Anda, termasuk posisi, perusahaan, dan periode kerja"></textarea>
-                                    <small class="text-muted">Contoh: Software Developer di PT ABC (2020-2023), Web Designer di PT XYZ (2018-2020)</small>
-                                    @error('state.pengalaman_kerja')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
+                                    <label class="form-label">{{ __('Riwayat Pengalaman Kerja') }}</label>
+                                    @foreach ($state['pengalaman_kerja'] as $index => $exp)
+                                        <div class="border rounded p-3 mb-3">
+                                            <div class="row g-2">
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Tanggal Mulai') }}</label>
+                                                    <input type="date" class="form-control" wire:model.defer="state.pengalaman_kerja.{{ $index }}.tanggal_mulai">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Tanggal Terakhir') }}</label>
+                                                    <input type="date" class="form-control" wire:model.defer="state.pengalaman_kerja.{{ $index }}.tanggal_selesai">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Nama Perusahaan') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.pengalaman_kerja.{{ $index }}.nama_perusahaan" placeholder="Masukkan nama perusahaan">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Keterangan Bisnis Perusahaan') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.pengalaman_kerja.{{ $index }}.keterangan_bisnis" placeholder="Masukkan keterangan bisnis">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Jabatan') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.pengalaman_kerja.{{ $index }}.jabatan" placeholder="Masukkan jabatan">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Alasan Keluar/Berhenti') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.pengalaman_kerja.{{ $index }}.alasan_keluar" placeholder="Masukkan alasan keluar">
+                                                </div>
+                                            </div>
+                                            <div class="text-end mt-2">
+                                                <button type="button" class="btn btn-sm btn-danger" wire:click="removeWorkExperience({{ $index }})">Hapus</button>
+                                            </div>
+                                        </div>
+                                    @endforeach
+                                    <button type="button" class="btn btn-outline-primary btn-sm" wire:click="addWorkExperience">Tambah Pengalaman</button>
+                                </div>
+
+                                <div class="col-12 mb-3" id="education">
+                                    <label class="form-label">{{ __('Riwayat Pendidikan') }}</label>
+                                    @foreach ($state['pendidikan'] as $index => $edu)
+                                        <div class="border rounded p-3 mb-3">
+                                            <div class="row g-2">
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Tanggal Mulai') }}</label>
+                                                    <input type="date" class="form-control" wire:model.defer="state.pendidikan.{{ $index }}.tanggal_mulai">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Tanggal Berakhir') }}</label>
+                                                    <input type="date" class="form-control" wire:model.defer="state.pendidikan.{{ $index }}.tanggal_selesai">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Nama Pendidikan') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.pendidikan.{{ $index }}.nama_pendidikan" placeholder="Masukkan nama pendidikan">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Jurusan') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.pendidikan.{{ $index }}.jurusan" placeholder="Masukkan jurusan">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Tingkat Pendidikan') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.pendidikan.{{ $index }}.tingkat" placeholder="Masukkan tingkat pendidikan">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">{{ __('Pendidikan Tertinggi') }}</label>
+                                                    <select class="form-select" wire:model.defer="state.pendidikan.{{ $index }}.pendidikan_tertinggi">
+                                                        <option value="Tidak">Tidak</option>
+                                                        <option value="Ya">Ya</option>
+                                                    </select>
+                                                </div>
+                                            </div>
+                                            <div class="text-end mt-2">
+                                                <button type="button" class="btn btn-sm btn-danger" wire:click="removeEducation({{ $index }})">Hapus</button>
+                                            </div>
+                                        </div>
+                                    @endforeach
+                                    <button type="button" class="btn btn-outline-primary btn-sm" wire:click="addEducation">Tambah Pendidikan</button>
                                 </div>
 
                                 <div class="col-12 mb-3" id="language">
-                                    <label for="kemampuan_bahasa" class="form-label">{{ __('Kemampuan Bahasa (Opsional)') }}</label>
-                                    <textarea id="kemampuan_bahasa" class="form-control @error('state.kemampuan_bahasa') is-invalid @enderror" 
-                                        wire:model.defer="state.kemampuan_bahasa" rows="2" 
-                                        placeholder="Sebutkan bahasa yang Anda kuasai dan tingkat kemahirannya"></textarea>
-                                    <small class="text-muted">Contoh: Indonesia (Native), Inggris (Menengah), Mandarin (Pemula)</small>
-                                    @error('state.kemampuan_bahasa')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
+                                    <label class="form-label">{{ __('Keterampilan Bahasa') }}</label>
+                                    @foreach ($state['kemampuan_bahasa'] as $index => $lang)
+                                        <div class="border rounded p-3 mb-3">
+                                            <div class="row g-2">
+                                                <div class="col-md-3">
+                                                    <label class="form-label">{{ __('Bahasa') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.kemampuan_bahasa.{{ $index }}.bahasa" placeholder="Masukkan bahasa">
+                                                </div>
+                                                <div class="col-md-3">
+                                                    <label class="form-label">{{ __('Berbicara') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.kemampuan_bahasa.{{ $index }}.bicara" placeholder="Kemahiran berbicara">
+                                                </div>
+                                                <div class="col-md-3">
+                                                    <label class="form-label">{{ __('Membaca') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.kemampuan_bahasa.{{ $index }}.membaca" placeholder="Kemahiran membaca">
+                                                </div>
+                                                <div class="col-md-3">
+                                                    <label class="form-label">{{ __('Menulis') }}</label>
+                                                    <input type="text" class="form-control" wire:model.defer="state.kemampuan_bahasa.{{ $index }}.menulis" placeholder="Kemahiran menulis">
+                                                </div>
+                                            </div>
+                                            <div class="text-end mt-2">
+                                                <button type="button" class="btn btn-sm btn-danger" wire:click="removeLanguage({{ $index }})">Hapus</button>
+                                            </div>
+                                        </div>
+                                    @endforeach
+                                    <button type="button" class="btn btn-outline-primary btn-sm" wire:click="addLanguage">Tambah Bahasa</button>
                                 </div>
                                 
                                 <div class="col-12 mb-3">


### PR DESCRIPTION
## Summary
- allow storing optional middle name for candidates and display it in profile
- overhaul candidate profile form with dynamic work experience, education, and language sections
- persist repeated profile sections as JSON via Livewire

## Testing
- `php artisan test` *(fails: require(/workspace/jobportal/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68a42b2c7f9083268fa91edcbb8ae012