### PR TITLE
Enable PDF preview and shrink image previews

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    'temporary_file_upload' => [
+        'disk' => null,
+        'directory' => null,
+        'middleware' => null,
+        'preview_mimes' => [
+            'jpg',
+            'jpeg',
+            'png',
+            'gif',
+            'bmp',
+            'svg',
+            'webp',
+            'pdf',
+        ],
+        'rules' => null,
+        'message' => null,
+        'max_upload_time' => 5,
+    ],
+];

--- a/resources/views/livewire/profile/show-profile.blade.php
+++ b/resources/views/livewire/profile/show-profile.blade.php
@@ -286,7 +286,7 @@
                                     @if(str_contains($ktp->getMimeType(), 'pdf'))
                                         <iframe src="{{ $ktp->temporaryUrl() }}" class="w-100" style="height: 400px;"></iframe>
                                     @else
-                                        <img src="{{ $ktp->temporaryUrl() }}" class="img-fluid rounded"/>
+                                        <img src="{{ $ktp->temporaryUrl() }}" class="img-fluid rounded" style="max-width: 200px;"/>
                                     @endif
                                 </div>
                             @endif
@@ -305,7 +305,7 @@
                                     @if(str_contains($ijazah->getMimeType(), 'pdf'))
                                         <iframe src="{{ $ijazah->temporaryUrl() }}" class="w-100" style="height: 400px;"></iframe>
                                     @else
-                                        <img src="{{ $ijazah->temporaryUrl() }}" class="img-fluid rounded"/>
+                                        <img src="{{ $ijazah->temporaryUrl() }}" class="img-fluid rounded" style="max-width: 200px;"/>
                                     @endif
                                 </div>
                             @endif
@@ -324,7 +324,7 @@
                                     @if(str_contains($sertifikat->getMimeType(), 'pdf'))
                                         <iframe src="{{ $sertifikat->temporaryUrl() }}" class="w-100" style="height: 400px;"></iframe>
                                     @else
-                                        <img src="{{ $sertifikat->temporaryUrl() }}" class="img-fluid rounded"/>
+                                        <img src="{{ $sertifikat->temporaryUrl() }}" class="img-fluid rounded" style="max-width: 200px;"/>
                                     @endif
                                 </div>
                             @endif
@@ -343,7 +343,7 @@
                                     @if(str_contains($surat_pengalaman->getMimeType(), 'pdf'))
                                         <iframe src="{{ $surat_pengalaman->temporaryUrl() }}" class="w-100" style="height: 400px;"></iframe>
                                     @else
-                                        <img src="{{ $surat_pengalaman->temporaryUrl() }}" class="img-fluid rounded"/>
+                                        <img src="{{ $surat_pengalaman->temporaryUrl() }}" class="img-fluid rounded" style="max-width: 200px;"/>
                                     @endif
                                 </div>
                             @endif
@@ -362,7 +362,7 @@
                                     @if(str_contains($skck->getMimeType(), 'pdf'))
                                         <iframe src="{{ $skck->temporaryUrl() }}" class="w-100" style="height: 400px;"></iframe>
                                     @else
-                                        <img src="{{ $skck->temporaryUrl() }}" class="img-fluid rounded"/>
+                                        <img src="{{ $skck->temporaryUrl() }}" class="img-fluid rounded" style="max-width: 200px;"/>
                                     @endif
                                 </div>
                             @endif
@@ -381,7 +381,7 @@
                                     @if(str_contains($surat_sehat->getMimeType(), 'pdf'))
                                         <iframe src="{{ $surat_sehat->temporaryUrl() }}" class="w-100" style="height: 400px;"></iframe>
                                     @else
-                                        <img src="{{ $surat_sehat->temporaryUrl() }}" class="img-fluid rounded"/>
+                                        <img src="{{ $surat_sehat->temporaryUrl() }}" class="img-fluid rounded" style="max-width: 200px;"/>
                                     @endif
                                 </div>
                             @endif


### PR DESCRIPTION
## Summary
- allow Livewire temporary uploads to preview PDF files
- reduce size of image previews in profile document upload modal

## Testing
- `composer test` (fails: require vendor/autoload.php: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a52ce2bcec832698115bc04f533ed7