### PR TITLE
feat: add per-lowongan document requirements

### DIFF
--- a/app/Livewire/Kandidat/Dashboard.php
+++ b/app/Livewire/Kandidat/Dashboard.php
@@ -7,17 +7,20 @@ use Livewire\Component;
 use App\Models\Lowongan;
 use App\Models\Kandidat;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Livewire\WithPagination;
+use Livewire\WithFileUploads;
 
 class Dashboard extends Component
 {
-    use WithPagination;
+    use WithPagination, WithFileUploads;
 
     public $showJobModal = false;
     public $showProfileModal = false;
     public $showBmiTestModal = false;
     public $showBlindTestModal = false;
     public $showResultModal = false;
+    public $showDocumentModal = false;
     public $selectedLowongan;
     
     // Properti untuk form kandidat
@@ -51,6 +54,17 @@ class Dashboard extends Component
     public $total_blind_tests = 5;
     public $blind_test_options = [];
     public $testResults = [];
+    public $requiredDocuments = [];
+    public $missingDocuments = [];
+    public $documents = [];
+
+    // Uploaded document placeholders
+    public $ktp;
+    public $ijazah;
+    public $sertifikat;
+    public $surat_pengalaman;
+    public $skck;
+    public $surat_sehat;
 
     protected $correct_blind_test_answers = [ 1 => '8', 2 => '29', 3 => '5', 4 => '6', 5 => '42' ];
 
@@ -143,6 +157,8 @@ class Dashboard extends Component
             if (!$user->kandidat) $this->showProfileModal = true;
             elseif (!$user->kandidat->bmi_score) $this->showBmiTestModal = true;
             elseif (!$user->kandidat->blind_score) $this->showBlindTestModal = true;
+            elseif (!$this->hasRequiredDocuments($this->selectedLowongan))
+                $this->openDocumentModal();
             else $this->showJobModal = true;
         } else {
             // Alur untuk pengguna tamu: langsung mulai tes
@@ -264,6 +280,87 @@ class Dashboard extends Component
 
         if ($meetsBmi && $meetsBlind) {
             $this->dispatch('prompt-auth-after-test');
+        }
+    }
+
+    public function openDocumentModal()
+    {
+        $this->resetUploadFields();
+        $this->refreshDocuments();
+        $this->showDocumentModal = true;
+    }
+
+    public function closeDocumentModal()
+    {
+        $this->showDocumentModal = false;
+    }
+
+    protected function resetUploadFields()
+    {
+        $this->ktp = $this->ijazah = $this->sertifikat = $this->surat_pengalaman = $this->skck = $this->surat_sehat = null;
+    }
+
+    protected function getUserDocuments()
+    {
+        $userId = Auth::id();
+        $path = "documents/{$userId}";
+        $files = [];
+        if (Storage::disk('public')->exists($path)) {
+            foreach (Storage::disk('public')->files($path) as $file) {
+                $name = pathinfo($file, PATHINFO_FILENAME);
+                $files[$name] = Storage::url($file);
+            }
+        }
+        return $files;
+    }
+
+    protected function refreshDocuments()
+    {
+        $this->documents = $this->getUserDocuments();
+    }
+
+    protected function hasRequiredDocuments($lowongan)
+    {
+        $this->requiredDocuments = $lowongan->dokumen_pendukung ?? [];
+        $userDocs = $this->getUserDocuments();
+        $this->missingDocuments = [];
+        foreach ($this->requiredDocuments as $doc) {
+            if (!isset($userDocs[$doc])) {
+                $this->missingDocuments[] = $doc;
+            }
+        }
+        return empty($this->missingDocuments);
+    }
+
+    public function uploadDocuments()
+    {
+        $userId = Auth::id();
+        $basePath = "documents/{$userId}";
+
+        if ($this->ktp) {
+            $this->ktp->storeAs($basePath, 'ktp.' . $this->ktp->getClientOriginalExtension(), 'public');
+        }
+        if ($this->ijazah) {
+            $this->ijazah->storeAs($basePath, 'ijazah.' . $this->ijazah->getClientOriginalExtension(), 'public');
+        }
+        if ($this->sertifikat) {
+            $this->sertifikat->storeAs($basePath, 'sertifikat.' . $this->sertifikat->getClientOriginalExtension(), 'public');
+        }
+        if ($this->surat_pengalaman) {
+            $this->surat_pengalaman->storeAs($basePath, 'surat_pengalaman.' . $this->surat_pengalaman->getClientOriginalExtension(), 'public');
+        }
+        if ($this->skck) {
+            $this->skck->storeAs($basePath, 'skck.' . $this->skck->getClientOriginalExtension(), 'public');
+        }
+        if ($this->surat_sehat) {
+            $this->surat_sehat->storeAs($basePath, 'surat_sehat.' . $this->surat_sehat->getClientOriginalExtension(), 'public');
+        }
+
+        $this->refreshDocuments();
+        $this->closeDocumentModal();
+
+        if ($this->selectedLowongan && $this->hasRequiredDocuments($this->selectedLowongan)) {
+            $this->showJobModal = true;
         }
     }
 

--- a/app/Livewire/Lowongan/Create.php
+++ b/app/Livewire/Lowongan/Create.php
@@ -22,6 +22,7 @@ class Create extends Component
     public $deskripsi = '';
     public $range_gaji;
     public $kemampuan_yang_dibutuhkan;
+    public $dokumen_pendukung = [];
 
     public $status = 'posted'; // draft|scheduled
 
@@ -59,6 +60,7 @@ class Create extends Component
             'deskripsi' => 'required|min:10',
             'range_gaji' => 'nullable|string',
             'kemampuan_yang_dibutuhkan' => 'nullable|string',
+            'dokumen_pendukung' => 'nullable|array',
         ];
     }
 
@@ -89,6 +91,7 @@ class Create extends Component
             'deskripsi' => $this->deskripsi,
             'range_gaji' => $this->range_gaji,
             'kemampuan_yang_dibutuhkan' => $this->kemampuan_yang_dibutuhkan,
+            'dokumen_pendukung' => $this->dokumen_pendukung,
             'is_active' => true,
             'status' => $this->status,
             'user_create' => Auth::id(),

--- a/app/Models/Lowongan.php
+++ b/app/Models/Lowongan.php
@@ -23,6 +23,7 @@ class Lowongan extends Model
         'deskripsi',
         'range_gaji',
         'kemampuan_yang_dibutuhkan',
+        'dokumen_pendukung',
         'is_aktif',
         'kategori_lowongan_id',
         'user_create',
@@ -34,6 +35,7 @@ class Lowongan extends Model
         'tanggal_berakhir' => 'date',
         'is_remote' => 'boolean',
         'is_aktif' => 'boolean',
+        'dokumen_pendukung' => 'array',
     ];
 
     /**

--- a/database/migrations/2025_07_06_183242_create_lowongans_table.php
+++ b/database/migrations/2025_07_06_183242_create_lowongans_table.php
@@ -24,6 +24,7 @@ return new class extends Migration
             $table->text('deskripsi');
             $table->string('range_gaji')->nullable();
             $table->text('kemampuan_yang_dibutuhkan')->nullable();
+            $table->json('dokumen_pendukung')->nullable();
             $table->boolean('is_active')->default(true);
             $table->enum('status', ['posted', 'archived'])->default('posted');
             $table->foreignId('user_create')->constrained('users')->onDelete('cascade');

--- a/resources/views/livewire/kandidat/dashboard.blade.php
+++ b/resources/views/livewire/kandidat/dashboard.blade.php
@@ -1,4 +1,7 @@
 <div>
+    @php
+        use Illuminate\Support\Str;
+    @endphp
     <link rel="stylesheet" href="{{ asset('css/colorblind-test.css') }}">
     <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
         <div class="bg-overlay bg-gradient-overlay"></div>
@@ -578,6 +581,69 @@
                         </span>
                     </button>
                 </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal-backdrop fade show"></div>
+    @endif
+
+    {{-- MODAL DOCUMENT: Untuk Lengkapi Dokumen Pendukung --}}
+    @if($showDocumentModal)
+    <div class="modal fade show" style="display: block; background-color: rgba(0,0,0,0.5);" tabindex="-1" wire:ignore.self>
+        <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content rounded shadow-lg">
+                <form wire:submit.prevent="uploadDocuments">
+                    <div class="modal-header p-4">
+                        <h5 class="modal-title fw-bold">Unggah Dokumen Pendukung</h5>
+                        <button type="button" class="btn-close" wire:click="closeDocumentModal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body p-4">
+                        @if(!empty($requiredDocuments))
+                            <div class="alert alert-info">
+                                Dokumen yang diperlukan: {{ implode(', ', array_map(fn($d)=>Str::title(str_replace('_',' ', $d)), $requiredDocuments)) }}
+                            </div>
+                        @endif
+                        @php
+                            $labels = [
+                                'ktp' => 'KTP',
+                                'ijazah' => 'Ijazah',
+                                'sertifikat' => 'Sertifikat',
+                                'surat_pengalaman' => 'Surat Pengalaman Kerja',
+                                'skck' => 'SKCK',
+                                'surat_sehat' => 'Surat Sehat',
+                            ];
+                        @endphp
+                        @foreach($requiredDocuments as $doc)
+                            <div class="mb-3">
+                                <label class="form-label">{{ $labels[$doc] ?? Str::title(str_replace('_',' ', $doc)) }}</label>
+                                <input type="file" class="form-control" wire:model="{{$doc}}">
+                                @php $temp = data_get($this, $doc); $existing = $documents[$doc] ?? null; @endphp
+                                @if($temp)
+                                    <div class="mt-2">
+                                        <span class="d-block">Preview:</span>
+                                        @if(str_contains($temp->getMimeType(), 'pdf'))
+                                            <iframe src="{{ $temp->temporaryUrl() }}" class="w-100" style="height:400px;"></iframe>
+                                        @else
+                                            <img src="{{ $temp->temporaryUrl() }}" class="img-fluid rounded" style="max-width:200px;"/>
+                                        @endif
+                                    </div>
+                                @elseif($existing)
+                                    <div class="mt-2">
+                                        @if(Str::contains(Str::lower($existing), '.pdf'))
+                                            <iframe src="{{ $existing }}" class="w-100" style="height:400px;"></iframe>
+                                        @else
+                                            <img src="{{ $existing }}" class="img-fluid rounded" style="max-width:200px;"/>
+                                        @endif
+                                    </div>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                    <div class="modal-footer p-3 bg-light">
+                        <button type="button" class="btn btn-soft-secondary" wire:click="closeDocumentModal">Batal</button>
+                        <button type="submit" class="btn btn-primary">Upload</button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>

--- a/resources/views/livewire/lowongan/create.blade.php
+++ b/resources/views/livewire/lowongan/create.blade.php
@@ -174,6 +174,32 @@
                                     </div>
                                     <div class="col-12">
                                         <div class="mb-3">
+                                            <label class="form-label fw-semibold">Dokumen Pendukung Diperlukan:</label>
+                                            <div class="row">
+                                                @php
+                                                    $docs = [
+                                                        'ktp' => 'KTP',
+                                                        'ijazah' => 'Ijazah',
+                                                        'sertifikat' => 'Sertifikat',
+                                                        'surat_pengalaman' => 'Surat Pengalaman Kerja',
+                                                        'skck' => 'SKCK',
+                                                        'surat_sehat' => 'Surat Sehat',
+                                                    ];
+                                                @endphp
+                                                @foreach($docs as $key => $label)
+                                                    <div class="col-md-4">
+                                                        <div class="form-check">
+                                                            <input class="form-check-input" type="checkbox" id="doc_{{ $key }}" value="{{ $key }}" wire:model.defer="dokumen_pendukung">
+                                                            <label class="form-check-label" for="doc_{{ $key }}">{{ $label }}</label>
+                                                        </div>
+                                                    </div>
+                                                @endforeach
+                                            </div>
+                                            @error('dokumen_pendukung') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div class="mb-3">
                                             <label class="form-label fw-semibold">Photo:</label>
                                             <input type="file" wire:model="foto" class="form-control" accept="image/*">
                                             @error('foto') <div class="text-danger">{{ $message }}</div> @enderror


### PR DESCRIPTION
## Summary
- support storing required documents per job
- prompt candidates to upload missing documents during application
- allow specifying required documents when creating jobs

## Testing
- `php -l app/Livewire/Kandidat/Dashboard.php`
- `php -l app/Livewire/Lowongan/Create.php`
- `php -l app/Models/Lowongan.php`
- `php -l database/migrations/2025_07_06_183242_create_lowongans_table.php`
- `php artisan test` *(fails: Failed to open required '/workspace/jobportal/vendor/autoload.php')*
- `composer install` *(fails: requires GitHub token for downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68a5387ec6888326aaa944cc68baf615