### PR TITLE
feat(profile): add detailed sections and specific info

### DIFF
--- a/app/Livewire/Kandidat/CompleteApply.php
+++ b/app/Livewire/Kandidat/CompleteApply.php
@@ -23,9 +23,6 @@ class CompleteApply extends Component
     public $status_perkawinan;
     public $agama;
     public $no_telpon_alternatif;
-    public $pengalaman_kerja;
-    public $pendidikan;
-    public $kemampuan_bahasa;
     public $kemampuan;
 
     protected $kandidatRepository;
@@ -55,9 +52,6 @@ class CompleteApply extends Component
             $this->status_perkawinan = $kandidat->status_perkawinan;
             $this->agama = $kandidat->agama;
             $this->no_telpon_alternatif = $kandidat->no_telpon_alternatif;
-            $this->pengalaman_kerja = $kandidat->pengalaman_kerja;
-            $this->pendidikan = $kandidat->pendidikan;
-            $this->kemampuan_bahasa = $kandidat->kemampuan_bahasa;
             $this->kemampuan = $kandidat->kemampuan;
         }
     }
@@ -79,9 +73,6 @@ class CompleteApply extends Component
             'status_perkawinan' => 'nullable|string|max:255',
             'agama' => 'nullable|string|max:255',
             'no_telpon_alternatif' => 'nullable|string|max:15',
-            'pengalaman_kerja' => 'nullable|string|max:1000',
-            'pendidikan' => 'nullable|string|max:1000',
-            'kemampuan_bahasa' => 'nullable|string|max:1000',
             'kemampuan' => 'nullable|string|max:1000',
         ]);
 
@@ -103,9 +94,6 @@ class CompleteApply extends Component
                 'status_perkawinan' => $this->status_perkawinan,
                 'agama' => $this->agama,
                 'no_telpon_alternatif' => $this->no_telpon_alternatif,
-                'pengalaman_kerja' => $this->pengalaman_kerja,
-                'pendidikan' => $this->pendidikan,
-                'kemampuan_bahasa' => $this->kemampuan_bahasa,
                 'kemampuan' => $this->kemampuan,
             ]
         );

--- a/app/Livewire/Kandidat/Dashboard.php
+++ b/app/Livewire/Kandidat/Dashboard.php
@@ -35,9 +35,6 @@ class Dashboard extends Component
     public $jenis_kelamin;
     public $status_perkawinan;
     public $agama;
-    public $pendidikan;
-    public $pengalaman_kerja;
-    public $kemampuan_bahasa;
     public $kemampuan;
     
     // Properti untuk BMI Test
@@ -80,10 +77,7 @@ class Dashboard extends Component
             'jenis_kelamin' => 'required|in:L,P',
             'status_perkawinan' => 'required|string|max:50',
             'agama' => 'required|string|max:50',
-            'pendidikan' => 'required|string',
             'no_npwp' => 'nullable|string|max:25',
-            'pengalaman_kerja' => 'nullable|string',
-            'kemampuan_bahasa' => 'nullable|string',
             'kemampuan' => 'nullable|string',
             'tinggi_badan' => 'required|numeric|min:100|max:250',
             'berat_badan' => 'required|numeric|min:30|max:200',
@@ -119,10 +113,7 @@ class Dashboard extends Component
         //     'jenis_kelamin' => 'required|in:L,P',
         //     'status_perkawinan' => 'required|string|max:50',
         //     'agama' => 'required|string|max:50',
-        //     'pendidikan' => 'required|string',
         //     'no_npwp' => 'nullable|string|max:25',
-        //     'pengalaman_kerja' => 'nullable|string',
-        //     'kemampuan_bahasa' => 'nullable|string',
         //     'kemampuan' => 'nullable|string',
         // ];
         
@@ -289,8 +280,7 @@ class Dashboard extends Component
             $this->reset([
                 'nama_depan', 'nama_belakang', 'no_telpon', 'alamat', 'kode_pos', 'negara',
                 'no_ktp', 'no_npwp', 'tempat_lahir', 'tanggal_lahir', 'jenis_kelamin',
-                'status_perkawinan', 'agama', 'pendidikan', 'pengalaman_kerja',
-                'kemampuan_bahasa', 'kemampuan'
+                'status_perkawinan', 'agama', 'kemampuan'
             ]);
         }
     }

--- a/app/Livewire/Profile/UpdateEducationHistory.php
+++ b/app/Livewire/Profile/UpdateEducationHistory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Livewire\Profile;
+
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class UpdateEducationHistory extends Component
+{
+    public $educations = [];
+
+    public function mount()
+    {
+        $kandidat = Auth::user()->kandidat;
+        $this->educations = $kandidat->education_history ?? [
+            ['start' => '', 'end' => '', 'name' => '', 'major' => '', 'level' => '', 'highest' => false],
+        ];
+    }
+
+    public function addEducation()
+    {
+        $this->educations[] = ['start' => '', 'end' => '', 'name' => '', 'major' => '', 'level' => '', 'highest' => false];
+    }
+
+    public function removeEducation($index)
+    {
+        unset($this->educations[$index]);
+        $this->educations = array_values($this->educations);
+    }
+
+    public function save()
+    {
+        $this->validate([
+            'educations.*.start' => 'required|date',
+            'educations.*.end' => 'required|date',
+            'educations.*.name' => 'required|string',
+            'educations.*.major' => 'nullable|string',
+            'educations.*.level' => 'required|string',
+            'educations.*.highest' => 'boolean',
+        ]);
+
+        $kandidat = Auth::user()->kandidat;
+        $kandidat->update(['education_history' => $this->educations]);
+        session()->flash('status', 'Riwayat pendidikan tersimpan.');
+    }
+
+    public function render()
+    {
+        return view('livewire.profile.update-education-history');
+    }
+}

--- a/app/Livewire/Profile/UpdateKandidatProfileForm.php
+++ b/app/Livewire/Profile/UpdateKandidatProfileForm.php
@@ -58,10 +58,7 @@ class UpdateKandidatProfileForm extends Component
                 'jenis_kelamin' => '',
                 'status_perkawinan' => '',
                 'agama' => '',
-                'pendidikan' => '',
-                'pengalaman_kerja' => '',
-                'kemampuan_bahasa' => '',
-                'kemampuan' => '',
+                // new specific info fields will be edited separately
             ];
         }
     }
@@ -90,10 +87,6 @@ class UpdateKandidatProfileForm extends Component
             'state.jenis_kelamin' => ['required', 'in:L,P'],
             'state.status_perkawinan' => ['required', 'string', 'max:50'],
             'state.agama' => ['required', 'string', 'max:50'],
-            'state.pendidikan' => ['required', 'string'],
-            'state.pengalaman_kerja' => ['nullable', 'string'],
-            'state.kemampuan_bahasa' => ['nullable', 'string'],
-            'state.kemampuan' => ['nullable', 'string'],
         ]);
 
         // Gunakan updateOrCreate untuk membuat profil jika belum ada, atau memperbarui jika sudah ada

--- a/app/Livewire/Profile/UpdateLanguageSkills.php
+++ b/app/Livewire/Profile/UpdateLanguageSkills.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Livewire\Profile;
+
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class UpdateLanguageSkills extends Component
+{
+    public $languages = [];
+
+    public function mount()
+    {
+        $kandidat = Auth::user()->kandidat;
+        $this->languages = $kandidat->language_skills ?? [
+            ['language' => '', 'speaking' => '', 'reading' => '', 'writing' => ''],
+        ];
+    }
+
+    public function addLanguage()
+    {
+        $this->languages[] = ['language' => '', 'speaking' => '', 'reading' => '', 'writing' => ''];
+    }
+
+    public function removeLanguage($index)
+    {
+        unset($this->languages[$index]);
+        $this->languages = array_values($this->languages);
+    }
+
+    public function save()
+    {
+        $this->validate([
+            'languages.*.language' => 'required|string',
+            'languages.*.speaking' => 'required|string',
+            'languages.*.reading' => 'required|string',
+            'languages.*.writing' => 'required|string',
+        ]);
+
+        $kandidat = Auth::user()->kandidat;
+        $kandidat->update(['language_skills' => $this->languages]);
+        session()->flash('status', 'Keterampilan bahasa tersimpan.');
+    }
+
+    public function render()
+    {
+        return view('livewire.profile.update-language-skills');
+    }
+}

--- a/app/Livewire/Profile/UpdateSpecificInfo.php
+++ b/app/Livewire/Profile/UpdateSpecificInfo.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Livewire\Profile;
+
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class UpdateSpecificInfo extends Component
+{
+    public $worked_before;
+    public $previous_work_location;
+    public $job_info_source;
+    public $gender_identity;
+
+    public function mount()
+    {
+        $kandidat = Auth::user()->kandidat;
+        $this->worked_before = $kandidat->worked_before;
+        $this->previous_work_location = $kandidat->previous_work_location;
+        $this->job_info_source = $kandidat->job_info_source;
+        $this->gender_identity = $kandidat->gender_identity;
+    }
+
+    public function save()
+    {
+        $data = $this->validate([
+            'worked_before' => 'required|boolean',
+            'previous_work_location' => 'nullable|string',
+            'job_info_source' => 'required|string',
+            'gender_identity' => 'required|string',
+        ]);
+
+        Auth::user()->kandidat->update($data);
+        session()->flash('status', 'Informasi spesifik tersimpan.');
+    }
+
+    public function render()
+    {
+        return view('livewire.profile.update-specific-info');
+    }
+}

--- a/app/Livewire/Profile/UpdateWorkExperience.php
+++ b/app/Livewire/Profile/UpdateWorkExperience.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Livewire\Profile;
+
+use App\Models\Kandidat;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class UpdateWorkExperience extends Component
+{
+    public $experiences = [];
+
+    public function mount()
+    {
+        $kandidat = Auth::user()->kandidat;
+        $this->experiences = $kandidat->work_experiences ?? [
+            ['start' => '', 'end' => '', 'company' => '', 'business' => '', 'position' => '', 'reason' => ''],
+        ];
+    }
+
+    public function addExperience()
+    {
+        $this->experiences[] = ['start' => '', 'end' => '', 'company' => '', 'business' => '', 'position' => '', 'reason' => ''];
+    }
+
+    public function removeExperience($index)
+    {
+        unset($this->experiences[$index]);
+        $this->experiences = array_values($this->experiences);
+    }
+
+    public function save()
+    {
+        $this->validate([
+            'experiences.*.start' => 'required|date',
+            'experiences.*.end' => 'nullable|date',
+            'experiences.*.company' => 'required|string',
+            'experiences.*.business' => 'nullable|string',
+            'experiences.*.position' => 'required|string',
+            'experiences.*.reason' => 'nullable|string',
+        ]);
+
+        $kandidat = Auth::user()->kandidat;
+        $kandidat->update(['work_experiences' => $this->experiences]);
+        session()->flash('status', 'Riwayat pengalaman kerja tersimpan.');
+    }
+
+    public function render()
+    {
+        return view('livewire.profile.update-work-experience');
+    }
+}

--- a/app/Models/Kandidat.php
+++ b/app/Models/Kandidat.php
@@ -36,16 +36,27 @@ class Kandidat extends Model
         'bmi_score',
         'blind_score',
         'no_telpon_alternatif',
-        'pengalaman_kerja',
-        'pendidikan',
-        'kemampuan_bahasa',
+        // Detail sections stored as JSON
+        'work_experiences',
+        'education_history',
+        'language_skills',
+        // Additional skills
         'kemampuan',
+        // Specific information fields
+        'worked_before',
+        'previous_work_location',
+        'job_info_source',
+        'gender_identity',
         'user_create',
         'user_update',
     ];
 
     protected $casts = [
-        'tanggal_lahir' => 'date:Y-m-d'
+        'tanggal_lahir' => 'date:Y-m-d',
+        'work_experiences' => 'array',
+        'education_history' => 'array',
+        'language_skills' => 'array',
+        'worked_before' => 'boolean',
     ];
 
     /**

--- a/app/Repositories/KandidatRepository.php
+++ b/app/Repositories/KandidatRepository.php
@@ -22,9 +22,6 @@ class KandidatRepository extends Component
     public $status_perkawinan;
     public $agama;
     public $no_telpon_alternatif;
-    public $pengalaman_kerja;
-    public $pendidikan;
-    public $kemampuan_bahasa;
     public $kemampuan;
 
     protected $kandidatRepository;
@@ -57,9 +54,6 @@ class KandidatRepository extends Component
             $this->status_perkawinan = $kandidat->status_perkawinan;
             $this->agama = $kandidat->agama;
             $this->no_telpon_alternatif = $kandidat->no_telpon_alternatif;
-            $this->pengalaman_kerja = $kandidat->pengalaman_kerja;
-            $this->pendidikan = $kandidat->pendidikan;
-            $this->kemampuan_bahasa = $kandidat->kemampuan_bahasa;
             $this->kemampuan = $kandidat->kemampuan;
         }
     }
@@ -81,9 +75,6 @@ class KandidatRepository extends Component
             'status_perkawinan' => 'nullable|string|max:255',
             'agama' => 'nullable|string|max:255',
             'no_telpon_alternatif' => 'nullable|string|max:15',
-            'pengalaman_kerja' => 'nullable|string|max:1000',
-            'pendidikan' => 'nullable|string|max:1000',
-            'kemampuan_bahasa' => 'nullable|string|max:1000',
             'kemampuan' => 'nullable|string|max:1000',
         ]);
 
@@ -105,9 +96,6 @@ class KandidatRepository extends Component
                 'status_perkawinan' => $this->status_perkawinan,
                 'agama' => $this->agama,
                 'no_telpon_alternatif' => $this->no_telpon_alternatif,
-                'pengalaman_kerja' => $this->pengalaman_kerja,
-                'pendidikan' => $this->pendidikan,
-                'kemampuan_bahasa' => $this->kemampuan_bahasa,
                 'kemampuan' => $this->kemampuan,
             ]
         );

--- a/database/factories/KandidatFactory.php
+++ b/database/factories/KandidatFactory.php
@@ -40,10 +40,20 @@ class KandidatFactory extends Factory
             'bmi_score' => $this->faker->randomFloat(2, 15, 25),
             'blind_score' => 'normal',
             'no_telpon_alternatif' => $this->faker->phoneNumber(),
-            'pengalaman_kerja' => $this->faker->text(),
-            'pendidikan' => $this->faker->randomElement(['SD', 'SMP', 'SMA', 'D3', 'S1', 'S2']),
-            'kemampuan_bahasa' => $this->faker->text(),
+            'work_experiences' => [
+                ['start' => '2020-01-01', 'end' => '2021-01-01', 'company' => 'ABC', 'business' => 'IT', 'position' => 'Dev', 'reason' => ''],
+            ],
+            'education_history' => [
+                ['start' => '2015-01-01', 'end' => '2019-01-01', 'name' => 'Universitas X', 'major' => 'Teknik', 'level' => 'S1', 'highest' => true],
+            ],
+            'language_skills' => [
+                ['language' => 'Indonesia', 'speaking' => 'Baik', 'reading' => 'Baik', 'writing' => 'Baik'],
+            ],
             'kemampuan' => $this->faker->text(),
+            'worked_before' => false,
+            'previous_work_location' => null,
+            'job_info_source' => 'Internet',
+            'gender_identity' => 'Lainnya',
             'user_create' => 1, // Assuming user with ID 1 is the creator
             'user_update' => 1, // Assuming user with ID 1 is the updater
             'created_at' => now(),

--- a/database/migrations/2025_08_20_000001_add_profile_sections_to_kandidats_table.php
+++ b/database/migrations/2025_08_20_000001_add_profile_sections_to_kandidats_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('kandidats', function (Blueprint $table) {
+            // Drop old single-text fields
+            $table->dropColumn(['pengalaman_kerja', 'pendidikan', 'kemampuan_bahasa']);
+            // New JSON columns for detailed sections
+            $table->json('work_experiences')->nullable();
+            $table->json('education_history')->nullable();
+            $table->json('language_skills')->nullable();
+            // Specific information fields
+            $table->boolean('worked_before')->nullable();
+            $table->string('previous_work_location')->nullable();
+            $table->string('job_info_source')->nullable();
+            $table->string('gender_identity')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('kandidats', function (Blueprint $table) {
+            $table->dropColumn([
+                'work_experiences',
+                'education_history',
+                'language_skills',
+                'worked_before',
+                'previous_work_location',
+                'job_info_source',
+                'gender_identity',
+            ]);
+            // Re-add original columns
+            $table->text('pengalaman_kerja')->nullable();
+            $table->text('pendidikan')->nullable();
+            $table->text('kemampuan_bahasa')->nullable();
+        });
+    }
+};

--- a/resources/views/livewire/kandidat/complete-apply.blade.php
+++ b/resources/views/livewire/kandidat/complete-apply.blade.php
@@ -126,30 +126,6 @@
 
                 <div class="col-12">
                     <div class="mb-3">
-                        <label class="form-label fw-semibold">Work Experience:</label>
-                        <textarea wire:model="pengalaman_kerja" rows="4" class="form-control" placeholder="Work Experience :"></textarea>
-                        @error('pengalaman_kerja') <span class="text-danger">{{ $message }}</span> @enderror
-                    </div>
-                </div>
-
-                <div class="col-12">
-                    <div class="mb-3">
-                        <label class="form-label fw-semibold">Education:</label>
-                        <textarea wire:model="pendidikan" rows="4" class="form-control" placeholder="Education :"></textarea>
-                        @error('pendidikan') <span class="text-danger">{{ $message }}</span> @enderror
-                    </div>
-                </div>
-
-                <div class="col-12">
-                    <div class="mb-3">
-                        <label class="form-label fw-semibold">Language Skills:</label>
-                        <textarea wire:model="kemampuan_bahasa" rows="4" class="form-control" placeholder="Language Skills :"></textarea>
-                        @error('kemampuan_bahasa') <span class="text-danger">{{ $message }}</span> @enderror
-                    </div>
-                </div>
-
-                <div class="col-12">
-                    <div class="mb-3">
                         <label class="form-label fw-semibold">Skills:</label>
                         <textarea wire:model="kemampuan" rows="4" class="form-control" placeholder="Skills :"></textarea>
                         @error('kemampuan') <span class="text-danger">{{ $message }}</span> @enderror

--- a/resources/views/livewire/kandidat/dashboard.blade.php
+++ b/resources/views/livewire/kandidat/dashboard.blade.php
@@ -521,45 +521,9 @@
                             @endif
                             @endif
                             
-                            {{-- Data Pendidikan & Kemampuan --}}
-                            <div class="col-12 mb-4 mt-4">
-                                <h6 class="fw-bold text-primary border-bottom pb-2">Data Pendidikan & Kemampuan</h6>
-                            </div>
-                            
-                            <div class="col-12 mb-3">
-                                <label class="form-label">Pendidikan Terakhir <span class="text-danger">*</span></label>
-                                <select class="form-select @error('pendidikan') is-invalid @enderror" 
-                                    wire:model="pendidikan">
-                                    <option value="">Pilih Pendidikan</option>
-                                    <option value="SD">SD</option>
-                                    <option value="SMP">SMP</option>
-                                    <option value="SMA/SMK">SMA/SMK</option>
-                                    <option value="D1">D1</option>
-                                    <option value="D2">D2</option>
-                                    <option value="D3">D3</option>
-                                    <option value="D4">D4</option>
-                                    <option value="S1">S1</option>
-                                    <option value="S2">S2</option>
-                                    <option value="S3">S3</option>
-                                </select>
-                                @error('pendidikan') <div class="invalid-feedback">{{ $message }}</div> @enderror
-                            </div>
-                            
-                            <div class="col-12 mb-3">
-                                <label class="form-label">Pengalaman Kerja</label>
-                                <textarea class="form-control" wire:model="pengalaman_kerja" 
-                                    rows="3" placeholder="Deskripsikan pengalaman kerja Anda (opsional)"></textarea>
-                            </div>
-                            
-                            <div class="col-12 mb-3">
-                                <label class="form-label">Kemampuan Bahasa</label>
-                                <textarea class="form-control" wire:model="kemampuan_bahasa" 
-                                    rows="2" placeholder="Sebutkan bahasa yang Anda kuasai (opsional)"></textarea>
-                            </div>
-                            
                             <div class="col-12 mb-3">
                                 <label class="form-label">Kemampuan Lainnya</label>
-                                <textarea class="form-control" wire:model="kemampuan" 
+                                <textarea class="form-control" wire:model="kemampuan"
                                     rows="3" placeholder="Sebutkan kemampuan lain yang Anda miliki (opsional)"></textarea>
                             </div>
                         </div>

--- a/resources/views/livewire/officer/kandidat/index.blade.php
+++ b/resources/views/livewire/officer/kandidat/index.blade.php
@@ -138,11 +138,13 @@
                                 </div>
                                 <div class="col-12 mb-3">
                                     <label class="form-label">Pendidikan</label>
-                                    <p class="mb-0 fw-semibold">{{ $selectedKandidat->pendidikan }}</p>
+                                    @php $edu = collect($selectedKandidat->education_history ?? [])->first(); @endphp
+                                    <p class="mb-0 fw-semibold">{{ $edu['level'] ?? '-' }}</p>
                                 </div>
                                 <div class="col-12 mb-3">
                                     <label class="form-label">Pengalaman Kerja</label>
-                                    <p class="mb-0 fw-semibold">{{ $selectedKandidat->pengalaman_kerja }}</p>
+                                    @php $exp = collect($selectedKandidat->work_experiences ?? [])->first(); @endphp
+                                    <p class="mb-0 fw-semibold">{{ $exp['company'] ?? '-' }}</p>
                                 </div>
                                 <div class="col-12 mb-3">
                                     <label class="form-label">Kemampuan</label>

--- a/resources/views/livewire/profile/show-profile.blade.php
+++ b/resources/views/livewire/profile/show-profile.blade.php
@@ -183,30 +183,89 @@
                                 {{-- Divider --}}
                                 <hr class="my-4">
 
-                                {{-- Data Pendidikan & Kemampuan Section --}}
-                                <div class="row">
-                                    <div class="col-12 mb-4">
-                                        <h6 class="fw-bold text-primary border-bottom pb-2">
-                                            <i class="mdi mdi-school-outline me-2"></i>Data Pendidikan & Kemampuan
-                                        </h6>
-                                    </div>
-                                    <div class="col-md-12 mb-3">
-                                        <h6 class="text-muted mb-0">Pendidikan Terakhir</h6>
-                                        <p class="fw-medium">{{ $kandidat->pendidikan }}</p>
-                                    </div>
-                                    <div class="col-md-12 mb-3">
-                                        <h6 class="text-muted mb-0">Pengalaman Kerja</h6>
-                                        <p class="fw-medium" style="white-space: pre-wrap;">{{ $kandidat->pengalaman_kerja ?? '-' }}</p>
-                                    </div>
-                                    <div class="col-md-12 mb-3">
-                                        <h6 class="text-muted mb-0">Kemampuan Bahasa</h6>
-                                        <p class="fw-medium" style="white-space: pre-wrap;">{{ $kandidat->kemampuan_bahasa ?? '-' }}</p>
-                                    </div>
-                                    <div class="col-md-12 mb-3">
-                                        <h6 class="text-muted mb-0">Keahlian Lainnya</h6>
-                                        <p class="fw-medium" style="white-space: pre-wrap;">{{ $kandidat->kemampuan ?? '-' }}</p>
-                                    </div>
-                                </div>
+                                {{-- Riwayat dan Kemampuan Section --}}
+        <div class="row">
+            <div class="col-12 mb-4">
+                <h6 class="fw-bold text-primary border-bottom pb-2">
+                    <i class="mdi mdi-school-outline me-2"></i>Riwayat & Kemampuan
+                </h6>
+            </div>
+
+            <div class="col-12 mb-3">
+                <div class="d-flex justify-content-between">
+                    <h6 class="text-muted mb-0">Riwayat Pengalaman Kerja</h6>
+                    <a href="{{ route('profile.experience') }}" class="btn btn-sm btn-link">Edit</a>
+                </div>
+                @php $experiences = $kandidat->work_experiences ?? []; @endphp
+                @forelse ($experiences as $exp)
+                    <p class="fw-medium mb-1">{{ $exp['start'] ?? '-' }} - {{ $exp['end'] ?? '-' }} | {{ $exp['company'] ?? '-' }} ({{ $exp['position'] ?? '-' }})</p>
+                    <p class="text-muted mb-2">{{ $exp['business'] ?? '-' }} | Alasan: {{ $exp['reason'] ?? '-' }}</p>
+                @empty
+                    <p class="fw-medium">-</p>
+                @endforelse
+            </div>
+
+            <div class="col-12 mb-3">
+                <div class="d-flex justify-content-between">
+                    <h6 class="text-muted mb-0">Riwayat Pendidikan</h6>
+                    <a href="{{ route('profile.education') }}" class="btn btn-sm btn-link">Edit</a>
+                </div>
+                @php $educations = $kandidat->education_history ?? []; @endphp
+                @forelse ($educations as $edu)
+                    <p class="fw-medium mb-1">{{ $edu['start'] ?? '-' }} - {{ $edu['end'] ?? '-' }} | {{ $edu['name'] ?? '-' }} ({{ $edu['major'] ?? '-' }})</p>
+                    <p class="text-muted mb-2">Tingkat: {{ $edu['level'] ?? '-' }} | Tertinggi: {{ !empty($edu['highest']) ? 'Ya' : 'Tidak' }}</p>
+                @empty
+                    <p class="fw-medium">-</p>
+                @endforelse
+            </div>
+
+            <div class="col-12 mb-3">
+                <div class="d-flex justify-content-between">
+                    <h6 class="text-muted mb-0">Keterampilan Bahasa</h6>
+                    <a href="{{ route('profile.language') }}" class="btn btn-sm btn-link">Edit</a>
+                </div>
+                @php $languages = $kandidat->language_skills ?? []; @endphp
+                @forelse ($languages as $lang)
+                    <p class="fw-medium mb-1">{{ $lang['language'] ?? '-' }}</p>
+                    <p class="text-muted mb-2">Bicara: {{ $lang['speaking'] ?? '-' }}, Baca: {{ $lang['reading'] ?? '-' }}, Tulis: {{ $lang['writing'] ?? '-' }}</p>
+                @empty
+                    <p class="fw-medium">-</p>
+                @endforelse
+            </div>
+
+            <div class="col-12 mb-3">
+                <h6 class="text-muted mb-0">Keahlian Lainnya</h6>
+                <p class="fw-medium" style="white-space: pre-wrap;">{{ $kandidat->kemampuan ?? '-' }}</p>
+            </div>
+        </div>
+
+        {{-- Informasi Spesifik --}}
+        <div class="row mt-4">
+            <div class="col-12 mb-4">
+                <h6 class="fw-bold text-primary border-bottom pb-2">
+                    <i class="mdi mdi-information-outline me-2"></i>Informasi Spesifik
+                </h6>
+            </div>
+            <div class="col-12 mb-3">
+                <div class="d-flex justify-content-between">
+                    <span>Pernah bekerja di perusahaan ini?</span>
+                    <a href="{{ route('profile.specific') }}" class="btn btn-sm btn-link">Edit</a>
+                </div>
+                <p class="fw-medium">{{ $kandidat->worked_before ? 'Ya' : 'Tidak' }}</p>
+            </div>
+            <div class="col-12 mb-3">
+                <h6 class="text-muted mb-0">Lokasi bekerja sebelumnya</h6>
+                <p class="fw-medium">{{ $kandidat->previous_work_location ?? '-' }}</p>
+            </div>
+            <div class="col-12 mb-3">
+                <h6 class="text-muted mb-0">Sumber informasi pekerjaan</h6>
+                <p class="fw-medium">{{ $kandidat->job_info_source ?? '-' }}</p>
+            </div>
+            <div class="col-12 mb-3">
+                <h6 class="text-muted mb-0">Identifikasi Jenis Kelamin</h6>
+                <p class="fw-medium">{{ $kandidat->gender_identity ?? '-' }}</p>
+            </div>
+        </div>
 
                                 {{-- Divider --}}
                                 <hr class="my-4">

--- a/resources/views/livewire/profile/update-education-history.blade.php
+++ b/resources/views/livewire/profile/update-education-history.blade.php
@@ -1,0 +1,95 @@
+<div>
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12 text-center">
+                    <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">Riwayat Pendidikan</h5>
+                    <p class="text-white-50 para-desc mx-auto mb-0">Tambahkan riwayat pendidikan Anda di sini.</p>
+                </div>
+            </div>
+            <div class="position-middle-bottom">
+                <nav aria-label="breadcrumb" class="d-block">
+                    <ul class="breadcrumb breadcrumb-muted mb-0 p-0">
+                        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">Dashboard</a></li>
+                        <li class="breadcrumb-item"><a href="{{ route('profile.show') }}">Profile</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">Pendidikan</li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </section>
+
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-10">
+                    <div class="card border-0 shadow rounded">
+                        <div class="card-header bg-primary p-4">
+                            <h5 class="card-title text-white mb-0">Riwayat Pendidikan</h5>
+                        </div>
+                        <form wire:submit.prevent="save" class="card-body p-4">
+                            @foreach ($educations as $index => $edu)
+                                <div class="border rounded p-3 mb-3">
+                                    <div class="row g-2">
+                                        <div class="col-md-6">
+                                            <label class="form-label">Tanggal Mulai</label>
+                                            <input type="date" class="form-control" wire:model.defer="educations.{{ $index }}.start">
+                                            @error('educations.' . $index . '.start') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Tanggal Selesai</label>
+                                            <input type="date" class="form-control" wire:model.defer="educations.{{ $index }}.end">
+                                            @error('educations.' . $index . '.end') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Nama Pendidikan</label>
+                                            <input type="text" class="form-control" wire:model.defer="educations.{{ $index }}.name">
+                                            @error('educations.' . $index . '.name') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Jurusan</label>
+                                            <input type="text" class="form-control" wire:model.defer="educations.{{ $index }}.major">
+                                            @error('educations.' . $index . '.major') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Tingkat Pendidikan</label>
+                                            <input type="text" class="form-control" wire:model.defer="educations.{{ $index }}.level">
+                                            @error('educations.' . $index . '.level') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Pendidikan Tertinggi</label>
+                                            <select class="form-select" wire:model.defer="educations.{{ $index }}.highest">
+                                                <option value="0">Tidak</option>
+                                                <option value="1">Ya</option>
+                                            </select>
+                                            @error('educations.' . $index . '.highest') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-12 text-end">
+                                            <button type="button" class="btn btn-sm btn-danger" wire:click="removeEducation({{ $index }})">Hapus</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            @endforeach
+                            <div class="mb-3">
+                                <button type="button" class="btn btn-sm btn-secondary" wire:click="addEducation">Tambah Pendidikan</button>
+                            </div>
+                            <div class="d-flex justify-content-end">
+                                <a href="{{ route('profile.show') }}" class="btn btn-soft-secondary me-2">Kembali</a>
+                                <button type="submit" class="btn btn-primary">Simpan</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
+++ b/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
@@ -227,68 +227,6 @@
                             {{-- Divider --}}
                             <hr class="my-4">
 
-                            {{-- Data Pendidikan & Kemampuan Section --}}
-                            <div class="row">
-                                <div class="col-12 mb-4">
-                                    <h6 class="fw-bold text-primary border-bottom pb-2">
-                                        <i class="mdi mdi-school-outline me-2"></i>Data Pendidikan & Kemampuan
-                                    </h6>
-                                </div>
-
-                                <div class="col-md-6 mb-3">
-                                    <label for="pendidikan" class="form-label">{{ __('Pendidikan Terakhir') }} <span class="text-danger">*</span></label>
-                                    <select id="pendidikan" wire:model.defer="state.pendidikan" class="form-select @error('state.pendidikan') is-invalid @enderror">
-                                        <option value="">Pilih...</option>
-                                        <option value="SD">SD</option>
-                                        <option value="SMP">SMP</option>
-                                        <option value="SMA/SMK">SMA/SMK</option>
-                                        <option value="D1">D1</option>
-                                        <option value="D2">D2</option>
-                                        <option value="D3">D3</option>
-                                        <option value="D4">D4</option>
-                                        <option value="S1">S1</option>
-                                        <option value="S2">S2</option>
-                                        <option value="S3">S3</option>
-                                    </select>
-                                    @error('state.pendidikan')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
-                                </div>
-                                
-                                <div class="col-12 mb-3">
-                                    <label for="pengalaman_kerja" class="form-label">{{ __('Pengalaman Kerja (Opsional)') }}</label>
-                                    <textarea id="pengalaman_kerja" class="form-control @error('state.pengalaman_kerja') is-invalid @enderror" 
-                                        wire:model.defer="state.pengalaman_kerja" rows="4" 
-                                        placeholder="Deskripsikan pengalaman kerja Anda, termasuk posisi, perusahaan, dan periode kerja"></textarea>
-                                    <small class="text-muted">Contoh: Software Developer di PT ABC (2020-2023), Web Designer di PT XYZ (2018-2020)</small>
-                                    @error('state.pengalaman_kerja')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
-                                </div>
-
-                                <div class="col-12 mb-3">
-                                    <label for="kemampuan_bahasa" class="form-label">{{ __('Kemampuan Bahasa (Opsional)') }}</label>
-                                    <textarea id="kemampuan_bahasa" class="form-control @error('state.kemampuan_bahasa') is-invalid @enderror" 
-                                        wire:model.defer="state.kemampuan_bahasa" rows="2" 
-                                        placeholder="Sebutkan bahasa yang Anda kuasai dan tingkat kemahirannya"></textarea>
-                                    <small class="text-muted">Contoh: Indonesia (Native), Inggris (Menengah), Mandarin (Pemula)</small>
-                                    @error('state.kemampuan_bahasa')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
-                                </div>
-                                
-                                <div class="col-12 mb-3">
-                                    <label for="kemampuan" class="form-label">{{ __('Keahlian (Opsional)') }}</label>
-                                    <textarea id="kemampuan" class="form-control @error('state.kemampuan') is-invalid @enderror" 
-                                        wire:model.defer="state.kemampuan" rows="4" 
-                                        placeholder="Sebutkan keahlian yang Anda miliki, seperti bahasa pemrograman, software, sertifikasi, dll"></textarea>
-                                    <small class="text-muted">Contoh: JavaScript, PHP, Laravel, MySQL, Adobe Photoshop, Google Analytics</small>
-                                    @error('state.kemampuan')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
-                                </div>
-                            </div>
-
                             {{-- Action Buttons --}}
                             <div class="row">
                                 <div class="col-12">

--- a/resources/views/livewire/profile/update-language-skills.blade.php
+++ b/resources/views/livewire/profile/update-language-skills.blade.php
@@ -1,0 +1,82 @@
+<div>
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12 text-center">
+                    <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">Keterampilan Bahasa</h5>
+                    <p class="text-white-50 para-desc mx-auto mb-0">Tambahkan kemampuan bahasa Anda di sini.</p>
+                </div>
+            </div>
+            <div class="position-middle-bottom">
+                <nav aria-label="breadcrumb" class="d-block">
+                    <ul class="breadcrumb breadcrumb-muted mb-0 p-0">
+                        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">Dashboard</a></li>
+                        <li class="breadcrumb-item"><a href="{{ route('profile.show') }}">Profile</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">Bahasa</li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </section>
+
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-10">
+                    <div class="card border-0 shadow rounded">
+                        <div class="card-header bg-primary p-4">
+                            <h5 class="card-title text-white mb-0">Keterampilan Bahasa</h5>
+                        </div>
+                        <form wire:submit.prevent="save" class="card-body p-4">
+                            @foreach ($languages as $index => $lang)
+                                <div class="border rounded p-3 mb-3">
+                                    <div class="row g-2">
+                                        <div class="col-md-6">
+                                            <label class="form-label">Bahasa</label>
+                                            <input type="text" class="form-control" wire:model.defer="languages.{{ $index }}.language">
+                                            @error('languages.' . $index . '.language') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Kemahiran Berbicara</label>
+                                            <input type="text" class="form-control" wire:model.defer="languages.{{ $index }}.speaking">
+                                            @error('languages.' . $index . '.speaking') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Kemahiran Membaca</label>
+                                            <input type="text" class="form-control" wire:model.defer="languages.{{ $index }}.reading">
+                                            @error('languages.' . $index . '.reading') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Kemahiran Menulis</label>
+                                            <input type="text" class="form-control" wire:model.defer="languages.{{ $index }}.writing">
+                                            @error('languages.' . $index . '.writing') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-12 text-end">
+                                            <button type="button" class="btn btn-sm btn-danger" wire:click="removeLanguage({{ $index }})">Hapus</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            @endforeach
+                            <div class="mb-3">
+                                <button type="button" class="btn btn-sm btn-secondary" wire:click="addLanguage">Tambah Bahasa</button>
+                            </div>
+                            <div class="d-flex justify-content-end">
+                                <a href="{{ route('profile.show') }}" class="btn btn-soft-secondary me-2">Kembali</a>
+                                <button type="submit" class="btn btn-primary">Simpan</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/resources/views/livewire/profile/update-specific-info.blade.php
+++ b/resources/views/livewire/profile/update-specific-info.blade.php
@@ -1,0 +1,74 @@
+<div>
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12 text-center">
+                    <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">Informasi Spesifik</h5>
+                    <p class="text-white-50 para-desc mx-auto mb-0">Lengkapi informasi tambahan Anda.</p>
+                </div>
+            </div>
+            <div class="position-middle-bottom">
+                <nav aria-label="breadcrumb" class="d-block">
+                    <ul class="breadcrumb breadcrumb-muted mb-0 p-0">
+                        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">Dashboard</a></li>
+                        <li class="breadcrumb-item"><a href="{{ route('profile.show') }}">Profile</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">Informasi Spesifik</li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </section>
+
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-8">
+                    <div class="card border-0 shadow rounded">
+                        <div class="card-header bg-primary p-4">
+                            <h5 class="card-title text-white mb-0">Informasi Spesifik</h5>
+                        </div>
+                        <form wire:submit.prevent="save" class="card-body p-4">
+                            <div class="mb-3">
+                                <label class="form-label">Apakah pernah bekerja di perusahaan ini sebelumnya?</label>
+                                <select class="form-select" wire:model.defer="worked_before">
+                                    <option value="">Pilih...</option>
+                                    <option value="1">Ya</option>
+                                    <option value="0">Tidak</option>
+                                </select>
+                                @error('worked_before') <div class="text-danger">{{ $message }}</div> @enderror
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Jika ya, di lokasi mana Anda bekerja?</label>
+                                <input type="text" class="form-control" wire:model.defer="previous_work_location">
+                                @error('previous_work_location') <div class="text-danger">{{ $message }}</div> @enderror
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Bagaimana Anda mendapatkan informasi pekerjaan ini?</label>
+                                <input type="text" class="form-control" wire:model.defer="job_info_source">
+                                @error('job_info_source') <div class="text-danger">{{ $message }}</div> @enderror
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Identifikasi Jenis Kelamin</label>
+                                <input type="text" class="form-control" wire:model.defer="gender_identity">
+                                @error('gender_identity') <div class="text-danger">{{ $message }}</div> @enderror
+                            </div>
+                            <div class="d-flex justify-content-end">
+                                <a href="{{ route('profile.show') }}" class="btn btn-soft-secondary me-2">Kembali</a>
+                                <button type="submit" class="btn btn-primary">Simpan</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/resources/views/livewire/profile/update-work-experience.blade.php
+++ b/resources/views/livewire/profile/update-work-experience.blade.php
@@ -1,0 +1,92 @@
+<div>
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12 text-center">
+                    <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">Riwayat Pengalaman Kerja</h5>
+                    <p class="text-white-50 para-desc mx-auto mb-0">Tambahkan pengalaman kerja Anda di sini.</p>
+                </div>
+            </div>
+            <div class="position-middle-bottom">
+                <nav aria-label="breadcrumb" class="d-block">
+                    <ul class="breadcrumb breadcrumb-muted mb-0 p-0">
+                        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">Dashboard</a></li>
+                        <li class="breadcrumb-item"><a href="{{ route('profile.show') }}">Profile</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">Pengalaman Kerja</li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </section>
+
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-10">
+                    <div class="card border-0 shadow rounded">
+                        <div class="card-header bg-primary p-4">
+                            <h5 class="card-title text-white mb-0">Riwayat Pengalaman Kerja</h5>
+                        </div>
+                        <form wire:submit.prevent="save" class="card-body p-4">
+                            @foreach ($experiences as $index => $exp)
+                                <div class="border rounded p-3 mb-3">
+                                    <div class="row g-2">
+                                        <div class="col-md-6">
+                                            <label class="form-label">Tanggal Mulai</label>
+                                            <input type="date" class="form-control" wire:model.defer="experiences.{{ $index }}.start">
+                                            @error('experiences.' . $index . '.start') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Tanggal Selesai</label>
+                                            <input type="date" class="form-control" wire:model.defer="experiences.{{ $index }}.end">
+                                            @error('experiences.' . $index . '.end') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Nama Perusahaan</label>
+                                            <input type="text" class="form-control" wire:model.defer="experiences.{{ $index }}.company">
+                                            @error('experiences.' . $index . '.company') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Keterangan Bisnis</label>
+                                            <input type="text" class="form-control" wire:model.defer="experiences.{{ $index }}.business">
+                                            @error('experiences.' . $index . '.business') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Jabatan</label>
+                                            <input type="text" class="form-control" wire:model.defer="experiences.{{ $index }}.position">
+                                            @error('experiences.' . $index . '.position') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Alasan Berhenti</label>
+                                            <input type="text" class="form-control" wire:model.defer="experiences.{{ $index }}.reason">
+                                            @error('experiences.' . $index . '.reason') <div class="text-danger">{{ $message }}</div> @enderror
+                                        </div>
+                                        <div class="col-12 text-end">
+                                            <button type="button" class="btn btn-sm btn-danger" wire:click="removeExperience({{ $index }})">Hapus</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            @endforeach
+                            <div class="mb-3">
+                                <button type="button" class="btn btn-sm btn-secondary" wire:click="addExperience">Tambah Pengalaman</button>
+                            </div>
+                            <div class="d-flex justify-content-end">
+                                <a href="{{ route('profile.show') }}" class="btn btn-soft-secondary me-2">Kembali</a>
+                                <button type="submit" class="btn btn-primary">Simpan</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,4 +44,8 @@ Route::middleware([
     Route::get('/cbt/test', App\Livewire\Cbt\Test::class)->name('cbt.test');
     Route::get('/profile', App\Livewire\Profile\ShowProfile::class)->name('profile.show');
     Route::get('/profile/edit', App\Livewire\Profile\UpdateKandidatProfileForm::class)->name('profile.edit');
+    Route::get('/profile/experience', App\Livewire\Profile\UpdateWorkExperience::class)->name('profile.experience');
+    Route::get('/profile/education', App\Livewire\Profile\UpdateEducationHistory::class)->name('profile.education');
+    Route::get('/profile/language', App\Livewire\Profile\UpdateLanguageSkills::class)->name('profile.language');
+    Route::get('/profile/specific-info', App\Livewire\Profile\UpdateSpecificInfo::class)->name('profile.specific');
 });


### PR DESCRIPTION
## Summary
- overhaul candidate profile view to show work, education, language, and specific info
- introduce dedicated edit forms for experience, education, language skills, and specific info
- extend kandidat model and migration with JSON fields and specific info flags

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a53fef37248326bdf70b36cac22ea2