### PR TITLE
Add modular profile sections with standalone edit views

### DIFF
--- a/resources/views/livewire/profile/edit-education-history.blade.php
+++ b/resources/views/livewire/profile/edit-education-history.blade.php
@@ -1,0 +1,87 @@
+<div>
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12">
+                    <div class="title-heading text-center">
+                        <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">Riwayat Pendidikan</h5>
+                        <p class="text-white-50 para-desc mx-auto mb-0">Tambah atau perbarui riwayat pendidikan Anda.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12">
+                    <div class="card border-0 shadow rounded">
+                        <div class="card-header bg-primary p-4">
+                            <h5 class="card-title text-white mb-0">Riwayat Pendidikan</h5>
+                        </div>
+                        <form class="card-body p-4">
+                            <div id="education-container">
+                                <div class="row g-3 border rounded p-3 mb-3 education-item">
+                                    <div class="col-md-6">
+                                        <label class="form-label">Tanggal Mulai Pendidikan</label>
+                                        <input type="date" class="form-control" name="edu_start[]">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Tanggal Berakhir Pendidikan</label>
+                                        <input type="date" class="form-control" name="edu_end[]">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Nama Pendidikan</label>
+                                        <input type="text" class="form-control" name="edu_name[]" placeholder="Nama Institusi">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Jurusan</label>
+                                        <input type="text" class="form-control" name="major[]" placeholder="Jurusan">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Tingkat Pendidikan</label>
+                                        <input type="text" class="form-control" name="level[]" placeholder="Tingkat Pendidikan">
+                                    </div>
+                                    <div class="col-md-6 d-flex align-items-center">
+                                        <div class="form-check mt-4">
+                                            <input class="form-check-input" type="checkbox" name="highest[]">
+                                            <label class="form-check-label">Pendidikan Tertinggi</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="addEducation()">
+                                <i class="mdi mdi-plus me-1"></i>Tambah Pendidikan
+                            </button>
+                            <div class="d-flex justify-content-end mt-4">
+                                <button type="submit" class="btn btn-primary">Simpan</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+<script>
+function addEducation() {
+    const container = document.getElementById('education-container');
+    const item = container.querySelector('.education-item').cloneNode(true);
+    item.querySelectorAll('input').forEach(input => {
+        if (input.type === 'checkbox') {
+            input.checked = false;
+        } else {
+            input.value = '';
+        }
+    });
+    container.appendChild(item);
+}
+</script>

--- a/resources/views/livewire/profile/edit-language-skill.blade.php
+++ b/resources/views/livewire/profile/edit-language-skill.blade.php
@@ -1,0 +1,89 @@
+<div>
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12">
+                    <div class="title-heading text-center">
+                        <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">Keterampilan Bahasa</h5>
+                        <p class="text-white-50 para-desc mx-auto mb-0">Tambah atau perbarui keterampilan bahasa Anda.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12">
+                    <div class="card border-0 shadow rounded">
+                        <div class="card-header bg-primary p-4">
+                            <h5 class="card-title text-white mb-0">Keterampilan Bahasa</h5>
+                        </div>
+                        <form class="card-body p-4">
+                            <div id="language-container">
+                                <div class="row g-3 border rounded p-3 mb-3 language-item">
+                                    <div class="col-md-3">
+                                        <label class="form-label">Bahasa</label>
+                                        <select class="form-select" name="language[]">
+                                            <option value="">Pilih Bahasa</option>
+                                            <option value="Indonesia">Indonesia</option>
+                                            <option value="Inggris">Inggris</option>
+                                            <option value="Jepang">Jepang</option>
+                                            <option value="Mandarin">Mandarin</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label class="form-label">Kemahiran Berbicara</label>
+                                        <select class="form-select" name="speak[]">
+                                            <option value="Dasar">Dasar</option>
+                                            <option value="Menengah">Menengah</option>
+                                            <option value="Mahir">Mahir</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label class="form-label">Kemahiran Membaca</label>
+                                        <select class="form-select" name="read[]">
+                                            <option value="Dasar">Dasar</option>
+                                            <option value="Menengah">Menengah</option>
+                                            <option value="Mahir">Mahir</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label class="form-label">Kemahiran Menulis</label>
+                                        <select class="form-select" name="write[]">
+                                            <option value="Dasar">Dasar</option>
+                                            <option value="Menengah">Menengah</option>
+                                            <option value="Mahir">Mahir</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="addLanguage()">
+                                <i class="mdi mdi-plus me-1"></i>Tambah Bahasa
+                            </button>
+                            <div class="d-flex justify-content-end mt-4">
+                                <button type="submit" class="btn btn-primary">Simpan</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+<script>
+function addLanguage() {
+    const container = document.getElementById('language-container');
+    const item = container.querySelector('.language-item').cloneNode(true);
+    item.querySelectorAll('select').forEach(select => select.selectedIndex = 0);
+    container.appendChild(item);
+}
+</script>

--- a/resources/views/livewire/profile/edit-specific-information.blade.php
+++ b/resources/views/livewire/profile/edit-specific-information.blade.php
@@ -1,0 +1,62 @@
+<div>
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12">
+                    <div class="title-heading text-center">
+                        <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">Spesifik Informasi</h5>
+                        <p class="text-white-50 para-desc mx-auto mb-0">Lengkapi informasi spesifik terkait pekerjaan.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12">
+                    <div class="card border-0 shadow rounded">
+                        <div class="card-header bg-primary p-4">
+                            <h5 class="card-title text-white mb-0">Spesifik Informasi</h5>
+                        </div>
+                        <form class="card-body p-4">
+                            <div class="mb-3">
+                                <label class="form-label">Apakah pernah bekerja di Perusahaan ini sebelumnya?</label>
+                                <select class="form-select" name="pernah_bekerja">
+                                    <option value="Tidak">Tidak</option>
+                                    <option value="Ya">Ya</option>
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Jika ya, di lokasi mana Anda bekerja?</label>
+                                <input type="text" class="form-control" name="lokasi_kerja" placeholder="Lokasi">
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Bagaimana Anda mendapatkan informasi pekerjaan ini?</label>
+                                <input type="text" class="form-control" name="sumber_info" placeholder="Sumber Informasi">
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Identifikasi Jenis Kelamin</label>
+                                <select class="form-select" name="identifikasi_kelamin">
+                                    <option value="Laki-laki">Laki-laki</option>
+                                    <option value="Perempuan">Perempuan</option>
+                                </select>
+                            </div>
+                            <div class="d-flex justify-content-end">
+                                <button type="submit" class="btn btn-primary">Simpan</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/resources/views/livewire/profile/edit-work-experience.blade.php
+++ b/resources/views/livewire/profile/edit-work-experience.blade.php
@@ -1,0 +1,79 @@
+<div>
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12">
+                    <div class="title-heading text-center">
+                        <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">Riwayat Pengalaman Kerja</h5>
+                        <p class="text-white-50 para-desc mx-auto mb-0">Tambah atau perbarui pengalaman kerja Anda.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12">
+                    <div class="card border-0 shadow rounded">
+                        <div class="card-header bg-primary p-4">
+                            <h5 class="card-title text-white mb-0">Pengalaman Kerja</h5>
+                        </div>
+                        <form class="card-body p-4">
+                            <div id="experience-container">
+                                <div class="row g-3 border rounded p-3 mb-3 experience-item">
+                                    <div class="col-md-6">
+                                        <label class="form-label">Tanggal Mulai Bekerja</label>
+                                        <input type="date" class="form-control" name="start[]">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Tanggal Terakhir Bekerja</label>
+                                        <input type="date" class="form-control" name="end[]">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Nama Perusahaan</label>
+                                        <input type="text" class="form-control" name="company[]" placeholder="Nama Perusahaan">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Keterangan Bisnis Perusahaan</label>
+                                        <input type="text" class="form-control" name="business[]" placeholder="Keterangan Bisnis">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Jabatan</label>
+                                        <input type="text" class="form-control" name="position[]" placeholder="Jabatan">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Alasan Keluar/Berhenti</label>
+                                        <input type="text" class="form-control" name="reason[]" placeholder="Alasan Keluar">
+                                    </div>
+                                </div>
+                            </div>
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="addExperience()">
+                                <i class="mdi mdi-plus me-1"></i>Tambah Pengalaman
+                            </button>
+                            <div class="d-flex justify-content-end mt-4">
+                                <button type="submit" class="btn btn-primary">Simpan</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+<script>
+function addExperience() {
+    const container = document.getElementById('experience-container');
+    const item = container.querySelector('.experience-item').cloneNode(true);
+    item.querySelectorAll('input').forEach(input => input.value = '');
+    container.appendChild(item);
+}
+</script>

--- a/resources/views/livewire/profile/show-profile.blade.php
+++ b/resources/views/livewire/profile/show-profile.blade.php
@@ -183,28 +183,90 @@
                                 {{-- Divider --}}
                                 <hr class="my-4">
 
-                                {{-- Data Pendidikan & Kemampuan Section --}}
+                                {{-- Riwayat Pengalaman Kerja --}}
+                                <div class="row">
+                                    <div class="col-12 mb-4 d-flex justify-content-between align-items-center">
+                                        <h6 class="fw-bold text-primary border-bottom pb-2">
+                                            <i class="mdi mdi-briefcase-outline me-2"></i>Riwayat Pengalaman Kerja
+                                        </h6>
+                                        <a href="{{ route('profile.experience.edit') }}" class="btn btn-sm btn-primary">
+                                            <i class="mdi mdi-pencil me-1"></i>Edit
+                                        </a>
+                                    </div>
+                                    <div class="col-12">
+                                        <p class="text-muted">Belum ada riwayat pengalaman kerja.</p>
+                                    </div>
+                                </div>
+
+                                {{-- Divider --}}
+                                <hr class="my-4">
+
+                                {{-- Riwayat Pendidikan --}}
+                                <div class="row">
+                                    <div class="col-12 mb-4 d-flex justify-content-between align-items-center">
+                                        <h6 class="fw-bold text-primary border-bottom pb-2">
+                                            <i class="mdi mdi-school-outline me-2"></i>Riwayat Pendidikan
+                                        </h6>
+                                        <a href="{{ route('profile.education.edit') }}" class="btn btn-sm btn-primary">
+                                            <i class="mdi mdi-pencil me-1"></i>Edit
+                                        </a>
+                                    </div>
+                                    <div class="col-12">
+                                        <p class="text-muted">Belum ada riwayat pendidikan.</p>
+                                    </div>
+                                </div>
+
+                                {{-- Divider --}}
+                                <hr class="my-4">
+
+                                {{-- Keterampilan Bahasa --}}
+                                <div class="row">
+                                    <div class="col-12 mb-4 d-flex justify-content-between align-items-center">
+                                        <h6 class="fw-bold text-primary border-bottom pb-2">
+                                            <i class="mdi mdi-translate me-2"></i>Keterampilan Bahasa
+                                        </h6>
+                                        <a href="{{ route('profile.language.edit') }}" class="btn btn-sm btn-primary">
+                                            <i class="mdi mdi-pencil me-1"></i>Edit
+                                        </a>
+                                    </div>
+                                    <div class="col-12">
+                                        <p class="text-muted">Belum ada keterampilan bahasa.</p>
+                                    </div>
+                                </div>
+
+                                {{-- Divider --}}
+                                <hr class="my-4">
+
+                                {{-- Keahlian Lainnya --}}
                                 <div class="row">
                                     <div class="col-12 mb-4">
                                         <h6 class="fw-bold text-primary border-bottom pb-2">
-                                            <i class="mdi mdi-school-outline me-2"></i>Data Pendidikan & Kemampuan
+                                            <i class="mdi mdi-lightbulb-outline me-2"></i>Keahlian Lainnya
                                         </h6>
                                     </div>
-                                    <div class="col-md-12 mb-3">
-                                        <h6 class="text-muted mb-0">Pendidikan Terakhir</h6>
-                                        <p class="fw-medium">{{ $kandidat->pendidikan }}</p>
-                                    </div>
-                                    <div class="col-md-12 mb-3">
-                                        <h6 class="text-muted mb-0">Pengalaman Kerja</h6>
-                                        <p class="fw-medium" style="white-space: pre-wrap;">{{ $kandidat->pengalaman_kerja ?? '-' }}</p>
-                                    </div>
-                                    <div class="col-md-12 mb-3">
-                                        <h6 class="text-muted mb-0">Kemampuan Bahasa</h6>
-                                        <p class="fw-medium" style="white-space: pre-wrap;">{{ $kandidat->kemampuan_bahasa ?? '-' }}</p>
-                                    </div>
-                                    <div class="col-md-12 mb-3">
-                                        <h6 class="text-muted mb-0">Keahlian Lainnya</h6>
+                                    <div class="col-12">
                                         <p class="fw-medium" style="white-space: pre-wrap;">{{ $kandidat->kemampuan ?? '-' }}</p>
+                                    </div>
+                                </div>
+
+                                {{-- Divider --}}
+                                <hr class="my-4">
+
+                                {{-- Spesifik Informasi --}}
+                                <div class="row">
+                                    <div class="col-12 mb-4 d-flex justify-content-between align-items-center">
+                                        <h6 class="fw-bold text-primary border-bottom pb-2">
+                                            <i class="mdi mdi-information-outline me-2"></i>Spesifik Informasi
+                                        </h6>
+                                        <a href="{{ route('profile.specific.edit') }}" class="btn btn-sm btn-primary">
+                                            <i class="mdi mdi-pencil me-1"></i>Edit
+                                        </a>
+                                    </div>
+                                    <div class="col-12">
+                                        <p class="text-muted mb-1">Apakah pernah bekerja di Perusahaan ini sebelumnya? -</p>
+                                        <p class="text-muted mb-1">Jika ya, di lokasi mana anda bekerja? -</p>
+                                        <p class="text-muted mb-1">Bagaimana anda mendapatkan informasi pekerjaan ini? -</p>
+                                        <p class="text-muted">Identifikasi jenis kelamin -</p>
                                     </div>
                                 </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,4 +44,8 @@ Route::middleware([
     Route::get('/cbt/test', App\Livewire\Cbt\Test::class)->name('cbt.test');
     Route::get('/profile', App\Livewire\Profile\ShowProfile::class)->name('profile.show');
     Route::get('/profile/edit', App\Livewire\Profile\UpdateKandidatProfileForm::class)->name('profile.edit');
+    Route::view('/profile/experience/edit', 'livewire.profile.edit-work-experience')->name('profile.experience.edit');
+    Route::view('/profile/education/edit', 'livewire.profile.edit-education-history')->name('profile.education.edit');
+    Route::view('/profile/language/edit', 'livewire.profile.edit-language-skill')->name('profile.language.edit');
+    Route::view('/profile/specific/edit', 'livewire.profile.edit-specific-information')->name('profile.specific.edit');
 });


### PR DESCRIPTION
## Summary
- Split candidate profile into sections for work experience, education history, language skills, and specific information
- Introduce separate Blade pages for editing each profile section
- Register routes for new profile editing views

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/jobportal/vendor/autoload.php')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a54acc58bc83269bd23a7a92f2face