### PR TITLE
feat: show candidate profile modal

### DIFF
--- a/app/Livewire/Officer/LamaranLowongan/Index.php
+++ b/app/Livewire/Officer/LamaranLowongan/Index.php
@@ -6,7 +6,9 @@ use Livewire\Component;
 use Livewire\WithPagination;
 use App\Models\LamarLowongan;
 use App\Models\User;
+use App\Models\Kandidat;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 
 class Index extends Component
 {
@@ -23,6 +25,11 @@ class Index extends Component
     public $interviewLink;
     public $interviewWaktu;
     public $interviewOfficer;
+
+    // Modal melihat profil kandidat
+    public $showProfileModal = false;
+    public $selectedKandidat;
+    public $documents = [];
 
 
     public function mount()
@@ -46,6 +53,34 @@ class Index extends Component
         return view('livewire.officer.lamaran-lowongan.index', [
             'lamaranList' => $lamaran
         ]);
+    }
+
+    public function openProfile($kandidatId)
+    {
+        $this->selectedKandidat = Kandidat::with('user')->find($kandidatId);
+        $this->loadDocuments();
+        $this->showProfileModal = true;
+    }
+
+    protected function loadDocuments()
+    {
+        $this->documents = [];
+        if ($this->selectedKandidat) {
+            $path = 'documents/' . $this->selectedKandidat->user_id;
+            if (Storage::disk('public')->exists($path)) {
+                foreach (Storage::disk('public')->files($path) as $file) {
+                    $name = pathinfo($file, PATHINFO_FILENAME);
+                    $this->documents[$name] = Storage::url($file);
+                }
+            }
+        }
+    }
+
+    public function closeProfile()
+    {
+        $this->showProfileModal = false;
+        $this->selectedKandidat = null;
+        $this->documents = [];
     }
 
     // Backward compatible dengan tombol lama

--- a/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
+++ b/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
@@ -109,6 +109,9 @@
                                                 <td class="text-center">{{ optional($lamaran->created_at)->format('d M Y') }}</td>
 
                                                 <td>
+                                                    <button class="btn btn-outline-primary btn-sm mb-2" wire:click="openProfile({{ $lamaran->kandidat_id }})">
+                                                        <i class="mdi mdi-eye"></i> Lihat Profil
+                                                    </button>
                                                     {{-- Badge status terakhir (jika ada) --}}
                                                     @if($latest)
                                                         <div class="mb-2">
@@ -234,6 +237,50 @@
                         <button type="submit" class="btn btn-primary">Simpan</button>
                     </div>
                 </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal Detail Kandidat -->
+    <div class="modal fade @if($showProfileModal) show @endif" tabindex="-1" style="@if($showProfileModal) display:block; @endif">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Detail Kandidat</h5>
+                    <button type="button" class="btn-close" wire:click="closeProfile"></button>
+                </div>
+                <div class="modal-body">
+                    @if($selectedKandidat)
+                        <div class="mb-4">
+                            <h6 class="fw-bold">Data Diri</h6>
+                            <p class="mb-1"><strong>Nama:</strong> {{ $selectedKandidat->full_name }}</p>
+                            <p class="mb-1"><strong>Email:</strong> {{ optional($selectedKandidat->user)->email }}</p>
+                            <p class="mb-1"><strong>No Telepon:</strong> {{ $selectedKandidat->no_telpon }}</p>
+                            <p class="mb-1"><strong>Alamat:</strong> {{ $selectedKandidat->formatted_address }}</p>
+                            <p class="mb-1"><strong>No KTP:</strong> {{ $selectedKandidat->no_ktp }}</p>
+                            <p class="mb-1"><strong>No NPWP:</strong> {{ $selectedKandidat->no_npwp }}</p>
+                            <p class="mb-1"><strong>Tempat, Tanggal Lahir:</strong> {{ $selectedKandidat->tempat_lahir }}, {{ optional($selectedKandidat->tanggal_lahir)->format('d M Y') }}</p>
+                            <p class="mb-1"><strong>Jenis Kelamin:</strong> {{ $selectedKandidat->jenis_kelamin }}</p>
+                            <p class="mb-1"><strong>Status Perkawinan:</strong> {{ $selectedKandidat->status_perkawinan }}</p>
+                            <p class="mb-1"><strong>Agama:</strong> {{ $selectedKandidat->agama }}</p>
+                        </div>
+                        <div>
+                            <h6 class="fw-bold">Dokumen Pendukung</h6>
+                            @if($documents)
+                                <ul class="list-unstyled mb-0">
+                                    @foreach($documents as $name => $url)
+                                        <li><a href="{{ $url }}" target="_blank" class="text-primary">{{ ucwords(str_replace('_',' ', $name)) }}</a></li>
+                                    @endforeach
+                                </ul>
+                            @else
+                                <p class="text-muted mb-0">Belum ada dokumen.</p>
+                            @endif
+                        </div>
+                    @endif
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" wire:click="closeProfile">Tutup</button>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- allow officers to open a modal showing candidate personal data and supporting documents

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: GitHub credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_68a568b7c46c8326928e75e72650804e