### PR TITLE
Store document paths on kandidat

### DIFF
--- a/app/Models/Kandidat.php
+++ b/app/Models/Kandidat.php
@@ -40,6 +40,12 @@ class Kandidat extends Model
         'pendidikan',
         'kemampuan_bahasa',
         'kemampuan',
+        'ktp_path',
+        'ijazah_path',
+        'sertifikat_path',
+        'surat_pengalaman_path',
+        'skck_path',
+        'surat_sehat_path',
         'user_create',
         'user_update',
     ];

--- a/database/migrations/2025_07_10_000000_add_document_paths_to_kandidats_table.php
+++ b/database/migrations/2025_07_10_000000_add_document_paths_to_kandidats_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('kandidats', function (Blueprint $table) {
+            $table->string('ktp_path')->nullable();
+            $table->string('ijazah_path')->nullable();
+            $table->string('sertifikat_path')->nullable();
+            $table->string('surat_pengalaman_path')->nullable();
+            $table->string('skck_path')->nullable();
+            $table->string('surat_sehat_path')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('kandidats', function (Blueprint $table) {
+            $table->dropColumn([
+                'ktp_path',
+                'ijazah_path',
+                'sertifikat_path',
+                'surat_pengalaman_path',
+                'skck_path',
+                'surat_sehat_path',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/profile/show-profile.blade.php
+++ b/resources/views/livewire/profile/show-profile.blade.php
@@ -247,22 +247,23 @@
                                         </button>
                                     </div>
 
-                                    @php
-                                        $docs = [
-                                            'ktp' => 'KTP',
-                                            'ijazah' => 'Ijazah',
-                                            'sertifikat' => 'Sertifikat',
-                                            'surat_pengalaman' => 'Surat Pengalaman Kerja',
-                                            'skck' => 'SKCK',
-                                            'surat_sehat' => 'Surat Sehat',
-                                        ];
-                                    @endphp
+@php
+    use Illuminate\Support\Facades\Storage;
+    $docs = [
+        'ktp' => 'KTP',
+        'ijazah' => 'Ijazah',
+        'sertifikat' => 'Sertifikat',
+        'surat_pengalaman' => 'Surat Pengalaman Kerja',
+        'skck' => 'SKCK',
+        'surat_sehat' => 'Surat Sehat',
+    ];
+@endphp
 
                                     @foreach ($docs as $key => $label)
                                         <div class="col-md-6 mb-3">
                                             <h6 class="text-muted mb-0">{{ $label }}</h6>
                                             @if (isset($documents[$key]))
-                                                <a href="{{ $documents[$key] }}" target="_blank" class="fw-medium text-primary">Lihat Dokumen</a>
+                                                <a href="{{ Storage::url($documents[$key]) }}" target="_blank" class="fw-medium text-primary">Lihat Dokumen</a>
                                             @else
                                                 <p class="fw-medium text-muted mb-0">Belum diunggah</p>
                                             @endif
@@ -301,7 +302,7 @@
                             <label class="form-label">KTP</label>
                             @if(isset($documents['ktp']))
                                 <div class="mb-2">
-                                    <a href="{{ $documents['ktp'] }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
+                                    <a href="{{ Storage::url($documents['ktp']) }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
                                 </div>
                             @endif
                             <input type="file" class="form-control" wire:model="ktp">
@@ -320,7 +321,7 @@
                             <label class="form-label">Ijazah</label>
                             @if(isset($documents['ijazah']))
                                 <div class="mb-2">
-                                    <a href="{{ $documents['ijazah'] }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
+                                    <a href="{{ Storage::url($documents['ijazah']) }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
                                 </div>
                             @endif
                             <input type="file" class="form-control" wire:model="ijazah">
@@ -339,7 +340,7 @@
                             <label class="form-label">Sertifikat</label>
                             @if(isset($documents['sertifikat']))
                                 <div class="mb-2">
-                                    <a href="{{ $documents['sertifikat'] }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
+                                    <a href="{{ Storage::url($documents['sertifikat']) }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
                                 </div>
                             @endif
                             <input type="file" class="form-control" wire:model="sertifikat">
@@ -358,7 +359,7 @@
                             <label class="form-label">Surat Pengalaman Kerja</label>
                             @if(isset($documents['surat_pengalaman']))
                                 <div class="mb-2">
-                                    <a href="{{ $documents['surat_pengalaman'] }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
+                                    <a href="{{ Storage::url($documents['surat_pengalaman']) }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
                                 </div>
                             @endif
                             <input type="file" class="form-control" wire:model="surat_pengalaman">
@@ -377,7 +378,7 @@
                             <label class="form-label">SKCK</label>
                             @if(isset($documents['skck']))
                                 <div class="mb-2">
-                                    <a href="{{ $documents['skck'] }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
+                                    <a href="{{ Storage::url($documents['skck']) }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
                                 </div>
                             @endif
                             <input type="file" class="form-control" wire:model="skck">
@@ -396,7 +397,7 @@
                             <label class="form-label">Surat Sehat</label>
                             @if(isset($documents['surat_sehat']))
                                 <div class="mb-2">
-                                    <a href="{{ $documents['surat_sehat'] }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
+                                    <a href="{{ Storage::url($documents['surat_sehat']) }}" target="_blank" class="text-primary">Lihat dokumen yang sudah diunggah</a>
                                 </div>
                             @endif
                             <input type="file" class="form-control" wire:model="surat_sehat">


### PR DESCRIPTION
## Summary
- save document paths on `kandidats` table and remove old files on upload
- fetch document URLs from saved paths for real-time profile updates
- allow migrations for new document path columns

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing, composer install blocked by network 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a572e8921083268801bab28784efb6