### PR TITLE
Implement officer position-based access control

### DIFF
--- a/app/Http/Middleware/PositionMiddleware.php
+++ b/app/Http/Middleware/PositionMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PositionMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  ...$positions
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handle(Request $request, Closure $next, ...$positions): Response
+    {
+        $user = $request->user();
+
+        if (!$user) {
+            return redirect('login');
+        }
+
+        foreach ($positions as $position) {
+            if ($user->hasPosition($position)) {
+                return $next($request);
+            }
+        }
+
+        abort(403, 'Unauthorized action.');
+    }
+}

--- a/app/Livewire/Officer/LamaranLowongan/Index.php
+++ b/app/Livewire/Officer/LamaranLowongan/Index.php
@@ -61,6 +61,11 @@ class Index extends Component
 
     public function setStatus($id, $status)
     {
+        if (auth()->user()->hasPosition('recruiter')) {
+            session()->flash('error', 'Aksi tidak diizinkan.');
+            return;
+        }
+
         $allowed = ['diterima', 'psikotes', 'ditolak'];
         if (!in_array($status, $allowed, true)) {
             session()->flash('error', 'Status tidak valid.');
@@ -96,6 +101,11 @@ class Index extends Component
 
     public function prepareInterview($lamaranId)
     {
+        if (auth()->user()->hasPosition('recruiter')) {
+            session()->flash('error', 'Aksi tidak diizinkan.');
+            return;
+        }
+
         $this->interviewLamaranId = $lamaranId;
         $this->interviewLink = '';
         $this->interviewWaktu = '';
@@ -105,6 +115,11 @@ class Index extends Component
 
     public function saveInterview()
     {
+        if (auth()->user()->hasPosition('recruiter')) {
+            session()->flash('error', 'Aksi tidak diizinkan.');
+            return;
+        }
+
         $this->validate([
             'interviewLink' => 'required|url',
             'interviewWaktu' => 'required|date',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,6 +11,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\Kandidat;
+use App\Models\Officer;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -79,6 +80,11 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->hasRole('officer') &&
                 $this->officer &&
                 $this->officer->jabatan === $position;
+    }
+
+    public function officer()
+    {
+        return $this->hasOne(Officer::class, 'user_id');
     }
 
     public function kandidat()

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\RoleMiddleware;
+use App\Http\Middleware\PositionMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -21,6 +22,7 @@ return Application::configure(basePath: dirname(__DIR__))
         // Register route middleware
         $middleware->alias([
             'role' => RoleMiddleware::class,
+            'position' => PositionMiddleware::class,
             // Other middleware aliases...
         ]);
     })

--- a/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
+++ b/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
@@ -142,16 +142,16 @@
 
                                                     {{-- Aksi cepat --}}
                                                     <div class="btn-group btn-group-sm" role="group" aria-label="Aksi lamaran">
-                                                        <button type="button" class="btn btn-outline-success" title="Terima" wire:click.prevent="setStatus({{ $lamaran->id }}, 'diterima')">
+                                                        <button type="button" class="btn btn-outline-success" title="Terima" wire:click.prevent="setStatus({{ $lamaran->id }}, 'diterima')" @if(auth()->user()->hasPosition('recruiter')) disabled @endif>
                                                             <i class="mdi mdi-check-circle-outline"></i>
                                                         </button>
-                                                        <button type="button" class="btn btn-outline-info" title="Jadwalkan Interview" wire:click.prevent="prepareInterview({{ $lamaran->id }})">
+                                                        <button type="button" class="btn btn-outline-info" title="Jadwalkan Interview" wire:click.prevent="prepareInterview({{ $lamaran->id }})" @if(auth()->user()->hasPosition('recruiter')) disabled @endif>
                                                             <i class="mdi mdi-calendar-clock"></i>
                                                         </button>
-                                                        <button type="button" class="btn btn-outline-warning" title="Psikotes" wire:click.prevent="setStatus({{ $lamaran->id }}, 'psikotes')">
+                                                        <button type="button" class="btn btn-outline-warning" title="Psikotes" wire:click.prevent="setStatus({{ $lamaran->id }}, 'psikotes')" @if(auth()->user()->hasPosition('recruiter')) disabled @endif>
                                                             <i class="mdi mdi-brain"></i>
                                                         </button>
-                                                        <button type="button" class="btn btn-outline-danger" title="Tolak" wire:click.prevent="setStatus({{ $lamaran->id }}, 'ditolak')">
+                                                        <button type="button" class="btn btn-outline-danger" title="Tolak" wire:click.prevent="setStatus({{ $lamaran->id }}, 'ditolak')" @if(auth()->user()->hasPosition('recruiter')) disabled @endif>
                                                             <i class="mdi mdi-close-circle-outline"></i>
                                                         </button>
                                                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,23 +12,28 @@ Route::middleware([
     'verified',
     'role:officer', // Ensure the user has the 'officer' role
 ])->group(function () {
-    Route::get('/officers', App\Livewire\Officer\Index::class)->name('officers.index');
     Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)->name('kategori-lowongan.Index');
     Route::get('/lowongan', App\Livewire\Lowongan\Index::class)->name('lowongan.index');
     Route::get('/lowongan/create', App\Livewire\Lowongan\Create::class)->name('lowongan.create');
     Route::get('/lowongan/{id}/edit', App\Livewire\Lowongan\Edit::class)->name('lowongan.edit');
-    Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)->name('recruitment.progress');
-    Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)->name('bank-soal.index');
-    Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)->name('kategori-soal.index');
     Route::get('/Lowongan/Index', App\Livewire\Lowongan\Index::class)->name('Lowongan.Index');
     Route::get('/Lowongan/Create', App\Livewire\Lowongan\Create::class)->name('Lowongan.Create');
     Route::get('/test-results', App\Livewire\Officer\TestResults\Index::class)->name('test-results.index');
-    Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)->name('kandidat.index');
     Route::get('/lamaran-lowongan', App\Livewire\Officer\LamaranLowongan\Index::class)
-    ->name('lamaran-lowongan.index');
-    Route::get('/jadwal-interview', App\Livewire\Officer\InterviewSchedule\Index::class)
-    ->name('jadwal-interview.index');
+        ->name('lamaran-lowongan.index');
 
+    Route::middleware('position:manager,coordinator')->group(function () {
+        Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)->name('bank-soal.index');
+        Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)->name('kategori-soal.index');
+    });
+
+    Route::middleware('position:manager')->group(function () {
+        Route::get('/officers', App\Livewire\Officer\Index::class)->name('officers.index');
+        Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)->name('recruitment.progress');
+        Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)->name('kandidat.index');
+        Route::get('/jadwal-interview', App\Livewire\Officer\InterviewSchedule\Index::class)
+            ->name('jadwal-interview.index');
+    });
 });
 
 Route::middleware([


### PR DESCRIPTION
## Summary
- add `PositionMiddleware` and register alias
- restrict officer routes by coordinator, recruiter, and manager positions
- prevent recruiter from performing lamaran actions and disable action buttons

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: requires GitHub token to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a675a4a120832689a0bb5f6471d0d5