### PR TITLE
Add officer position-based access control

### DIFF
--- a/app/Http/Middleware/OfficerPositionMiddleware.php
+++ b/app/Http/Middleware/OfficerPositionMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class OfficerPositionMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  ...$positions
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handle(Request $request, Closure $next, ...$positions): Response
+    {
+        if (!Auth::check()) {
+            return redirect('login');
+        }
+
+        $user = $request->user();
+
+        // Ensure user is an officer and has one of the required positions
+        $userPosition = optional($user->officer)->jabatan;
+
+        if (!$user->hasRole('officer') || !$userPosition || !in_array($userPosition, $positions, true)) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        return $next($request);
+    }
+}
+

--- a/app/Livewire/Officer/Index.php
+++ b/app/Livewire/Officer/Index.php
@@ -79,6 +79,14 @@ class Index extends Component
 
     public function openCreateModal()
     {
+        if (auth()->user()->hasPosition('recruiter')) {
+            $this->dispatch('showNotification', [
+                'status' => 'error',
+                'message' => __('Unauthorized action.')
+            ]);
+            return;
+        }
+
         $this->dispatch('showModal');
     }
 

--- a/app/Livewire/Officer/LamaranLowongan/Index.php
+++ b/app/Livewire/Officer/LamaranLowongan/Index.php
@@ -61,6 +61,11 @@ class Index extends Component
 
     public function setStatus($id, $status)
     {
+        if (auth()->user()->hasPosition('recruiter')) {
+            session()->flash('error', __('Unauthorized action.'));
+            return;
+        }
+
         $allowed = ['diterima', 'psikotes', 'ditolak'];
         if (!in_array($status, $allowed, true)) {
             session()->flash('error', 'Status tidak valid.');
@@ -96,6 +101,11 @@ class Index extends Component
 
     public function prepareInterview($lamaranId)
     {
+        if (auth()->user()->hasPosition('recruiter')) {
+            session()->flash('error', __('Unauthorized action.'));
+            return;
+        }
+
         $this->interviewLamaranId = $lamaranId;
         $this->interviewLink = '';
         $this->interviewWaktu = '';
@@ -105,6 +115,11 @@ class Index extends Component
 
     public function saveInterview()
     {
+        if (auth()->user()->hasPosition('recruiter')) {
+            session()->flash('error', __('Unauthorized action.'));
+            return;
+        }
+
         $this->validate([
             'interviewLink' => 'required|url',
             'interviewWaktu' => 'required|date',

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\RoleMiddleware;
+use App\Http\Middleware\OfficerPositionMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -21,6 +22,7 @@ return Application::configure(basePath: dirname(__DIR__))
         // Register route middleware
         $middleware->alias([
             'role' => RoleMiddleware::class,
+            'position' => OfficerPositionMiddleware::class,
             // Other middleware aliases...
         ]);
     })

--- a/resources/views/livewire/officer/index.blade.php
+++ b/resources/views/livewire/officer/index.blade.php
@@ -53,7 +53,9 @@
                     <div class="card border-0 rounded shadow">
                         <div class="card-header bg-white d-flex justify-content-between align-items-center">
                             <h5 class="card-title mb-0">{{ __('Officer List') }}</h5>
-                            <a href="#" wire:click.prevent="openCreateModal" class="btn btn-primary btn-sm">{{ __('Add New Officer') }}</a>
+                            @unless(auth()->user()->hasPosition('recruiter'))
+                                <a href="#" wire:click.prevent="openCreateModal" class="btn btn-primary btn-sm">{{ __('Add New Officer') }}</a>
+                            @endunless
                         </div>
                         <!-- Filter Section -->
                        <div class="card-body border-bottom">

--- a/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
+++ b/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
@@ -142,18 +142,33 @@
 
                                                     {{-- Aksi cepat --}}
                                                     <div class="btn-group btn-group-sm" role="group" aria-label="Aksi lamaran">
-                                                        <button type="button" class="btn btn-outline-success" title="Terima" wire:click.prevent="setStatus({{ $lamaran->id }}, 'diterima')">
-                                                            <i class="mdi mdi-check-circle-outline"></i>
-                                                        </button>
-                                                        <button type="button" class="btn btn-outline-info" title="Jadwalkan Interview" wire:click.prevent="prepareInterview({{ $lamaran->id }})">
-                                                            <i class="mdi mdi-calendar-clock"></i>
-                                                        </button>
-                                                        <button type="button" class="btn btn-outline-warning" title="Psikotes" wire:click.prevent="setStatus({{ $lamaran->id }}, 'psikotes')">
-                                                            <i class="mdi mdi-brain"></i>
-                                                        </button>
-                                                        <button type="button" class="btn btn-outline-danger" title="Tolak" wire:click.prevent="setStatus({{ $lamaran->id }}, 'ditolak')">
-                                                            <i class="mdi mdi-close-circle-outline"></i>
-                                                        </button>
+                                                        @if(auth()->user()->hasPosition('recruiter'))
+                                                            <button type="button" class="btn btn-outline-secondary" disabled title="{{ __('Unauthorized') }}">
+                                                                <i class="mdi mdi-check-circle-outline"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-secondary" disabled title="{{ __('Unauthorized') }}">
+                                                                <i class="mdi mdi-calendar-clock"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-secondary" disabled title="{{ __('Unauthorized') }}">
+                                                                <i class="mdi mdi-brain"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-secondary" disabled title="{{ __('Unauthorized') }}">
+                                                                <i class="mdi mdi-close-circle-outline"></i>
+                                                            </button>
+                                                        @else
+                                                            <button type="button" class="btn btn-outline-success" title="Terima" wire:click.prevent="setStatus({{ $lamaran->id }}, 'diterima')">
+                                                                <i class="mdi mdi-check-circle-outline"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-info" title="Jadwalkan Interview" wire:click.prevent="prepareInterview({{ $lamaran->id }})">
+                                                                <i class="mdi mdi-calendar-clock"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-warning" title="Psikotes" wire:click.prevent="setStatus({{ $lamaran->id }}, 'psikotes')">
+                                                                <i class="mdi mdi-brain"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-danger" title="Tolak" wire:click.prevent="setStatus({{ $lamaran->id }}, 'ditolak')">
+                                                                <i class="mdi mdi-close-circle-outline"></i>
+                                                            </button>
+                                                        @endif
                                                     </div>
                                                 </td>
                                             </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,23 +12,31 @@ Route::middleware([
     'verified',
     'role:officer', // Ensure the user has the 'officer' role
 ])->group(function () {
-    Route::get('/officers', App\Livewire\Officer\Index::class)->name('officers.index');
-    Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)->name('kategori-lowongan.Index');
-    Route::get('/lowongan', App\Livewire\Lowongan\Index::class)->name('lowongan.index');
-    Route::get('/lowongan/create', App\Livewire\Lowongan\Create::class)->name('lowongan.create');
-    Route::get('/lowongan/{id}/edit', App\Livewire\Lowongan\Edit::class)->name('lowongan.edit');
-    Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)->name('recruitment.progress');
-    Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)->name('bank-soal.index');
-    Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)->name('kategori-soal.index');
+    Route::middleware('position:manager,coordinator,recruiter')->group(function () {
+        Route::get('/officers', App\Livewire\Officer\Index::class)->name('officers.index');
+        Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)->name('kategori-lowongan.Index');
+        Route::get('/lowongan', App\Livewire\Lowongan\Index::class)->name('lowongan.index');
+        Route::get('/lowongan/create', App\Livewire\Lowongan\Create::class)->name('lowongan.create');
+        Route::get('/lowongan/{id}/edit', App\Livewire\Lowongan\Edit::class)->name('lowongan.edit');
+        Route::get('/lamaran-lowongan', App\Livewire\Officer\LamaranLowongan\Index::class)
+            ->name('lamaran-lowongan.index');
+        Route::get('/test-results', App\Livewire\Officer\TestResults\Index::class)->name('test-results.index');
+    });
+
+    Route::middleware('position:manager,coordinator')->group(function () {
+        Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)->name('bank-soal.index');
+        Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)->name('kategori-soal.index');
+    });
+
+    Route::middleware('position:manager')->group(function () {
+        Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)->name('recruitment.progress');
+        Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)->name('kandidat.index');
+        Route::get('/jadwal-interview', App\Livewire\Officer\InterviewSchedule\Index::class)
+            ->name('jadwal-interview.index');
+    });
+
     Route::get('/Lowongan/Index', App\Livewire\Lowongan\Index::class)->name('Lowongan.Index');
     Route::get('/Lowongan/Create', App\Livewire\Lowongan\Create::class)->name('Lowongan.Create');
-    Route::get('/test-results', App\Livewire\Officer\TestResults\Index::class)->name('test-results.index');
-    Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)->name('kandidat.index');
-    Route::get('/lamaran-lowongan', App\Livewire\Officer\LamaranLowongan\Index::class)
-    ->name('lamaran-lowongan.index');
-    Route::get('/jadwal-interview', App\Livewire\Officer\InterviewSchedule\Index::class)
-    ->name('jadwal-interview.index');
-
 });
 
 Route::middleware([


### PR DESCRIPTION
## Summary
- enforce officer position-based permissions with new middleware
- apply access limits across officer routes
- hide create officer actions from recruiters and disable lamaran actions for them

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: GitHub token required to download dasprid/enum)*

------
https://chatgpt.com/codex/tasks/task_e_68a67c6cb1f48326b3805fb2a03c0c70