### PR TITLE
Handle officer positions case-insensitively

### DIFF
--- a/app/Http/Middleware/OfficerPositionMiddleware.php
+++ b/app/Http/Middleware/OfficerPositionMiddleware.php
@@ -26,9 +26,10 @@ class OfficerPositionMiddleware
         $user = $request->user();
 
         // Ensure user is an officer and has one of the required positions
-        $userPosition = optional($user->officer)->jabatan;
+        $userPosition = strtolower(optional($user->officer)->jabatan);
+        $allowedPositions = array_map('strtolower', $positions);
 
-        if (!$user->hasRole('officer') || !$userPosition || !in_array($userPosition, $positions, true)) {
+        if (!$user->hasRole('officer') || !$userPosition || !in_array($userPosition, $allowedPositions, true)) {
             abort(403, 'Unauthorized action.');
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -78,7 +78,7 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->hasRole('officer') &&
                 $this->officer &&
-                $this->officer->jabatan === $position;
+                strtolower($this->officer->jabatan) === strtolower($position);
     }
 
     public function kandidat()


### PR DESCRIPTION
## Summary
- compare officer positions case-insensitively in User model
- normalize positions in OfficerPositionMiddleware to allow managers, coordinators, and recruiters access

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install --no-interaction --no-progress` *(fails: unable to download dependencies, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6808e56ec8326958a8338bc089c00