### PR TITLE
Implement officer role-specific route access

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -10,25 +10,34 @@ Route::middleware([
     'auth:sanctum',
     config('jetstream.auth_session'),
     'verified',
-    'role:officer', // Ensure the user has the 'officer' role
 ])->group(function () {
-    Route::get('/officers', App\Livewire\Officer\Index::class)->name('officers.index');
-    Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)->name('kategori-lowongan.Index');
-    Route::get('/lowongan', App\Livewire\Lowongan\Index::class)->name('lowongan.index');
-    Route::get('/lowongan/create', App\Livewire\Lowongan\Create::class)->name('lowongan.create');
-    Route::get('/lowongan/{id}/edit', App\Livewire\Lowongan\Edit::class)->name('lowongan.edit');
-    Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)->name('recruitment.progress');
-    Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)->name('bank-soal.index');
-    Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)->name('kategori-soal.index');
-    Route::get('/Lowongan/Index', App\Livewire\Lowongan\Index::class)->name('Lowongan.Index');
-    Route::get('/Lowongan/Create', App\Livewire\Lowongan\Create::class)->name('Lowongan.Create');
-    Route::get('/test-results', App\Livewire\Officer\TestResults\Index::class)->name('test-results.index');
-    Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)->name('kandidat.index');
-    Route::get('/lamaran-lowongan', App\Livewire\Officer\LamaranLowongan\Index::class)
-    ->name('lamaran-lowongan.index');
-    Route::get('/jadwal-interview', App\Livewire\Officer\InterviewSchedule\Index::class)
-    ->name('jadwal-interview.index');
+    // Routes that only managers can access
+    Route::middleware('role:manager')->group(function () {
+        Route::get('/officers', App\Livewire\Officer\Index::class)->name('officers.index');
+        Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)->name('recruitment.progress');
+        Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)->name('kandidat.index');
+        Route::get('/jadwal-interview', App\Livewire\Officer\InterviewSchedule\Index::class)
+            ->name('jadwal-interview.index');
+    });
 
+    // Routes shared by managers, recruiters and coordinators
+    Route::middleware('role:manager|recruiter|coordinator')->group(function () {
+        Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)->name('kategori-lowongan.Index');
+        Route::get('/lowongan', App\Livewire\Lowongan\Index::class)->name('lowongan.index');
+        Route::get('/lowongan/create', App\Livewire\Lowongan\Create::class)->name('lowongan.create');
+        Route::get('/lowongan/{id}/edit', App\Livewire\Lowongan\Edit::class)->name('lowongan.edit');
+        Route::get('/lamaran-lowongan', App\Livewire\Officer\LamaranLowongan\Index::class)
+            ->name('lamaran-lowongan.index');
+        Route::get('/test-results', App\Livewire\Officer\TestResults\Index::class)->name('test-results.index');
+        Route::get('/Lowongan/Index', App\Livewire\Lowongan\Index::class)->name('Lowongan.Index');
+        Route::get('/Lowongan/Create', App\Livewire\Lowongan\Create::class)->name('Lowongan.Create');
+    });
+
+    // Routes accessible to managers and coordinators only
+    Route::middleware('role:manager|coordinator')->group(function () {
+        Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)->name('bank-soal.index');
+        Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)->name('kategori-soal.index');
+    });
 });
 
 Route::middleware([


### PR DESCRIPTION
## Summary
- Add manager/recruiter/coordinator route groups for officers
- Limit access to lowongan, lamaran, and other menus based on officer roles

## Testing
- `composer test` *(fails: require(/workspace/jobportal/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading packages from api.github.com: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a68a72c17883268142ea40042cb0d5