### PR TITLE
Add officer role-based access control

### DIFF
--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -14,10 +14,10 @@ class RoleMiddleware
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @param  string  $role
+     * @param  mixed ...$roles
      * @return mixed
      */
-    public function handle(Request $request, Closure $next, $role)
+    public function handle(Request $request, Closure $next, ...$roles)
     {
         if (!Auth::check()) {
             return redirect('login');
@@ -25,19 +25,27 @@ class RoleMiddleware
 
         $user = $request->user();
 
-        // Jika user tidak memiliki role yang diperlukan
-        if (!$user->hasRole($role)) {
-            // Redirect berdasarkan role yang dimiliki user
-            if ($user->hasRole('officer')) {
-                return redirect()->route('officers.index');
-            } elseif ($user->hasRole('kandidat')) {
-                return redirect()->route('dashboard');
-            } else {
-                // User terautentikasi tapi tidak memiliki role yang valid
-                abort(403, 'Unauthorized action.');
+        foreach ($roles as $role) {
+            // Allow if user has role or matching position
+            if ($user->hasRole($role) || $user->hasPosition($role)) {
+                return $next($request);
+            }
+
+            // Manager has access to all officer features
+            if (in_array($role, ['officer', 'recruiter', 'coordinator', 'manager'])
+                && $user->hasPosition('manager')) {
+                return $next($request);
             }
         }
 
-        return $next($request);
+        // Redirect based on available role
+        if ($user->hasRole('officer')) {
+            return redirect()->route('officers.index');
+        } elseif ($user->hasRole('kandidat')) {
+            return redirect()->route('dashboard');
+        }
+
+        // User terautentikasi tapi tidak memiliki role yang valid
+        abort(403, 'Unauthorized action.');
     }
 }

--- a/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
+++ b/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
@@ -141,20 +141,37 @@
                                                     @endif
 
                                                     {{-- Aksi cepat --}}
-                                                    <div class="btn-group btn-group-sm" role="group" aria-label="Aksi lamaran">
-                                                        <button type="button" class="btn btn-outline-success" title="Terima" wire:click.prevent="setStatus({{ $lamaran->id }}, 'diterima')">
-                                                            <i class="mdi mdi-check-circle-outline"></i>
-                                                        </button>
-                                                        <button type="button" class="btn btn-outline-info" title="Jadwalkan Interview" wire:click.prevent="prepareInterview({{ $lamaran->id }})">
-                                                            <i class="mdi mdi-calendar-clock"></i>
-                                                        </button>
-                                                        <button type="button" class="btn btn-outline-warning" title="Psikotes" wire:click.prevent="setStatus({{ $lamaran->id }}, 'psikotes')">
-                                                            <i class="mdi mdi-brain"></i>
-                                                        </button>
-                                                        <button type="button" class="btn btn-outline-danger" title="Tolak" wire:click.prevent="setStatus({{ $lamaran->id }}, 'ditolak')">
-                                                            <i class="mdi mdi-close-circle-outline"></i>
-                                                        </button>
-                                                    </div>
+                                                    @if(auth()->user()->hasPosition('recruiter'))
+                                                        <div class="btn-group btn-group-sm" role="group" aria-label="Aksi lamaran">
+                                                            <button type="button" class="btn btn-outline-success" title="Terima" disabled>
+                                                                <i class="mdi mdi-check-circle-outline"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-info" title="Jadwalkan Interview" disabled>
+                                                                <i class="mdi mdi-calendar-clock"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-warning" title="Psikotes" disabled>
+                                                                <i class="mdi mdi-brain"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-danger" title="Tolak" disabled>
+                                                                <i class="mdi mdi-close-circle-outline"></i>
+                                                            </button>
+                                                        </div>
+                                                    @else
+                                                        <div class="btn-group btn-group-sm" role="group" aria-label="Aksi lamaran">
+                                                            <button type="button" class="btn btn-outline-success" title="Terima" wire:click.prevent="setStatus({{ $lamaran->id }}, 'diterima')">
+                                                                <i class="mdi mdi-check-circle-outline"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-info" title="Jadwalkan Interview" wire:click.prevent="prepareInterview({{ $lamaran->id }})">
+                                                                <i class="mdi mdi-calendar-clock"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-warning" title="Psikotes" wire:click.prevent="setStatus({{ $lamaran->id }}, 'psikotes')">
+                                                                <i class="mdi mdi-brain"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-outline-danger" title="Tolak" wire:click.prevent="setStatus({{ $lamaran->id }}, 'ditolak')">
+                                                                <i class="mdi mdi-close-circle-outline"></i>
+                                                            </button>
+                                                        </div>
+                                                    @endif
                                                 </td>
                                             </tr>
                                         @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,21 +13,32 @@ Route::middleware([
     'role:officer', // Ensure the user has the 'officer' role
 ])->group(function () {
     Route::get('/officers', App\Livewire\Officer\Index::class)->name('officers.index');
-    Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)->name('kategori-lowongan.Index');
-    Route::get('/lowongan', App\Livewire\Lowongan\Index::class)->name('lowongan.index');
-    Route::get('/lowongan/create', App\Livewire\Lowongan\Create::class)->name('lowongan.create');
-    Route::get('/lowongan/{id}/edit', App\Livewire\Lowongan\Edit::class)->name('lowongan.edit');
-    Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)->name('recruitment.progress');
-    Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)->name('bank-soal.index');
-    Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)->name('kategori-soal.index');
-    Route::get('/Lowongan/Index', App\Livewire\Lowongan\Index::class)->name('Lowongan.Index');
-    Route::get('/Lowongan/Create', App\Livewire\Lowongan\Create::class)->name('Lowongan.Create');
-    Route::get('/test-results', App\Livewire\Officer\TestResults\Index::class)->name('test-results.index');
-    Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)->name('kandidat.index');
+    Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)
+        ->middleware('role:recruiter,coordinator')->name('kategori-lowongan.Index');
+    Route::get('/lowongan', App\Livewire\Lowongan\Index::class)
+        ->middleware('role:recruiter,coordinator')->name('lowongan.index');
+    Route::get('/lowongan/create', App\Livewire\Lowongan\Create::class)
+        ->middleware('role:coordinator')->name('lowongan.create');
+    Route::get('/lowongan/{id}/edit', App\Livewire\Lowongan\Edit::class)
+        ->middleware('role:coordinator')->name('lowongan.edit');
+    Route::get('/recruitment-progress', App\Livewire\ProgressRekrutmenTimeline::class)
+        ->middleware('role:manager')->name('recruitment.progress');
+    Route::get('/bank-soal', App\Livewire\BankSoal\Index::class)
+        ->middleware('role:coordinator')->name('bank-soal.index');
+    Route::get('/kategori-soal', App\Livewire\KategoriSoal\Index::class)
+        ->middleware('role:coordinator')->name('kategori-soal.index');
+    Route::get('/Lowongan/Index', App\Livewire\Lowongan\Index::class)
+        ->middleware('role:recruiter,coordinator')->name('Lowongan.Index');
+    Route::get('/Lowongan/Create', App\Livewire\Lowongan\Create::class)
+        ->middleware('role:coordinator')->name('Lowongan.Create');
+    Route::get('/test-results', App\Livewire\Officer\TestResults\Index::class)
+        ->middleware('role:recruiter,coordinator')->name('test-results.index');
+    Route::get('kandidat', App\Livewire\Officer\Kandidat\Index::class)
+        ->middleware('role:manager')->name('kandidat.index');
     Route::get('/lamaran-lowongan', App\Livewire\Officer\LamaranLowongan\Index::class)
-    ->name('lamaran-lowongan.index');
+        ->middleware('role:recruiter,coordinator')->name('lamaran-lowongan.index');
     Route::get('/jadwal-interview', App\Livewire\Officer\InterviewSchedule\Index::class)
-    ->name('jadwal-interview.index');
+        ->middleware('role:manager')->name('jadwal-interview.index');
 
 });
 


### PR DESCRIPTION
## Summary
- Extend role middleware to handle officer positions and allow managers full access
- Restrict officer routes by position and add manager overrides
- Disable lamaran-lowongan action buttons for recruiters

## Testing
- `php artisan test` *(fails: requires Composer dependencies)*
- `composer install` *(fails: GitHub token required)*

------
https://chatgpt.com/codex/tasks/task_e_68a68ffdce8c8326a9e90583008b2b8b