### PR TITLE
Refactor education handling and fix profile data saving

### DIFF
--- a/app/Livewire/Profile/UpdateKandidatProfileForm.php
+++ b/app/Livewire/Profile/UpdateKandidatProfileForm.php
@@ -92,13 +92,33 @@ class UpdateKandidatProfileForm extends Component
             'state.jenis_kelamin' => ['required', 'in:L,P'],
             'state.status_perkawinan' => ['required', 'string', 'max:50'],
             'state.agama' => ['required', 'string', 'max:50'],
-            'state.pendidikan' => ['required', 'string'],
+            'state.pendidikan' => ['nullable', 'string'],
             'state.riwayat_pengalaman_kerja' => ['nullable', 'string'],
             'state.riwayat_pendidikan' => ['nullable', 'string'],
             'state.kemampuan_bahasa' => ['nullable', 'string'],
             'state.informasi_spesifik' => ['nullable', 'string'],
             'state.kemampuan' => ['nullable', 'string'],
         ]);
+
+        // Tentukan pendidikan tertinggi secara otomatis dari riwayat pendidikan
+        $educationHistory = json_decode($validatedData['state']['riwayat_pendidikan'] ?? '[]', true);
+        if (is_array($educationHistory) && !empty($educationHistory)) {
+            $levels = [
+                'SD', 'SMP', 'SMA/SMK', 'D1', 'D2', 'D3', 'D4', 'S1', 'S2', 'S3', 'Post Doktoral'
+            ];
+            $highest = null;
+            $currentMax = -1;
+            foreach ($educationHistory as $edu) {
+                $index = array_search($edu['level'] ?? '', $levels, true);
+                if ($index !== false && $index > $currentMax) {
+                    $currentMax = $index;
+                    $highest = $edu['level'];
+                }
+            }
+            $validatedData['state']['pendidikan'] = $highest;
+        } else {
+            $validatedData['state']['pendidikan'] = null;
+        }
 
         // Gunakan updateOrCreate untuk membuat profil jika belum ada, atau memperbarui jika sudah ada
         Kandidat::updateOrCreate(

--- a/resources/views/livewire/profile/show-profile.blade.php
+++ b/resources/views/livewire/profile/show-profile.blade.php
@@ -188,7 +188,7 @@
                                         </h6>
                                     </div>
                                     <div class="col-md-12 mb-3">
-                                        <h6 class="text-muted mb-0">Pendidikan Terakhir</h6>
+                                        <h6 class="text-muted mb-0">Pendidikan Tertinggi</h6>
                                         <p class="fw-medium">{{ $kandidat->pendidikan }}</p>
                                     </div>
                                     <div class="col-md-12 mb-3">
@@ -230,7 +230,7 @@
                                             <div class="col-12 mb-3">
                                                 <p class="mb-0 fw-medium">{{ $item['name'] ?? '-' }} - {{ $item['major'] ?? '-' }}</p>
                                                 <small class="text-muted">{{ $item['start'] ?? '-' }} - {{ $item['end'] ?? '-' }}</small>
-                                                <p class="mb-0">Tingkat: {{ $item['level'] ?? '-' }}@if(!empty($item['highest'])) (Tertinggi)@endif</p>
+                                                <p class="mb-0">Tingkat: {{ $item['level'] ?? '-' }}</p>
                                             </div>
                                         @endforeach
                                     @else

--- a/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
+++ b/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
@@ -235,26 +235,6 @@
                                     </h6>
                                 </div>
 
-                                <div class="col-md-6 mb-3">
-                                    <label for="pendidikan" class="form-label">{{ __('Pendidikan Terakhir') }} <span class="text-danger">*</span></label>
-                                    <select id="pendidikan" wire:model.defer="state.pendidikan" class="form-select @error('state.pendidikan') is-invalid @enderror">
-                                        <option value="">Pilih...</option>
-                                        <option value="SD">SD</option>
-                                        <option value="SMP">SMP</option>
-                                        <option value="SMA/SMK">SMA/SMK</option>
-                                        <option value="D1">D1</option>
-                                        <option value="D2">D2</option>
-                                        <option value="D3">D3</option>
-                                        <option value="D4">D4</option>
-                                        <option value="S1">S1</option>
-                                        <option value="S2">S2</option>
-                                        <option value="S3">S3</option>
-                                    </select>
-                                    @error('state.pendidikan')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
-                                </div>
-                                
                                 <div class="col-12 mb-3">
                                     <label class="form-label fw-bold"><i class="mdi mdi-briefcase-outline me-2"></i>Riwayat Pengalaman Kerja</label>
                                     <div id="work-experience-list"></div>
@@ -372,13 +352,20 @@
                                         </div>
                                         <div class="col-md-6 mb-3">
                                             <label>Tingkat Pendidikan</label>
-                                            <input type="text" class="form-control" name="edu_level[]">
-                                        </div>
-                                        <div class="col-md-6 mb-3 d-flex align-items-center">
-                                            <div class="form-check mt-4">
-                                                <input class="form-check-input" type="checkbox" name="edu_highest[]">
-                                                <label class="form-check-label">Pendidikan Tertinggi</label>
-                                            </div>
+                                            <select class="form-select" name="edu_level[]">
+                                                <option value="">Pilih...</option>
+                                                <option value="SD">SD</option>
+                                                <option value="SMP">SMP</option>
+                                                <option value="SMA/SMK">SMA/SMK</option>
+                                                <option value="D1">D1</option>
+                                                <option value="D2">D2</option>
+                                                <option value="D3">D3</option>
+                                                <option value="D4">D4</option>
+                                                <option value="S1">S1</option>
+                                                <option value="S2">S2</option>
+                                                <option value="S3">S3</option>
+                                                <option value="Post Doktoral">Post Doktoral</option>
+                                            </select>
                                         </div>
                                         <div class="col-12 text-end">
                                             <button type="button" class="btn btn-sm btn-danger remove-education">Hapus</button>
@@ -596,7 +583,6 @@
                     el.querySelector('[name="edu_name[]"]').value = item.name;
                     el.querySelector('[name="edu_major[]"]').value = item.major;
                     el.querySelector('[name="edu_level[]"]').value = item.level;
-                    el.querySelector('[name="edu_highest[]"]').checked = item.highest;
                     eduList.appendChild(tmpl);
                 });
 
@@ -649,7 +635,6 @@
                     name: el.querySelector('[name="edu_name[]"]').value,
                     major: el.querySelector('[name="edu_major[]"]').value,
                     level: el.querySelector('[name="edu_level[]"]').value,
-                    highest: el.querySelector('[name="edu_highest[]"]').checked,
                 }));
                 localStorage.setItem('education_history', JSON.stringify(eduData));
                 document.getElementById('riwayat_pendidikan').value = JSON.stringify(eduData);
@@ -670,7 +655,7 @@
                 };
                 localStorage.setItem('specific_info', JSON.stringify(specData));
                 document.getElementById('informasi_spesifik').value = JSON.stringify(specData);
-            });
+            }, true);
         });
     </script>
     @endpush


### PR DESCRIPTION
## Summary
- Compute highest education level automatically from education history
- Replace education level inputs with dropdowns and remove manual highest selector
- Ensure profile sections (work, education, language, specific info) persist and display properly

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: GitHub 403 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e883361883269962da5ee1a5d05e