### PR TITLE
Use single upload button for supporting documents

### DIFF
--- a/resources/views/livewire/profile/show-profile.blade.php
+++ b/resources/views/livewire/profile/show-profile.blade.php
@@ -326,16 +326,11 @@
                                         <div class="col-md-6 mb-3">
                                             <h6 class="text-muted mb-0">{{ $label }}</h6>
                                             @if (isset($documents[$key]))
-                                                <div>
-                                                    <a href="{{ Storage::url($documents[$key]) }}" target="_blank" class="fw-medium text-primary d-block mb-2">
-                                                        <i class="mdi mdi-eye-outline me-1"></i>Lihat Dokumen
-                                                    </a>
-                                                    <button type="button" wire:click="openDocumentModal('{{ $key }}')" class="btn btn-sm btn-outline-secondary">
-                                                        <i class="mdi mdi-swap-horizontal me-1"></i>Ganti
-                                                    </button>
-                                                </div>
+                                                <a href="{{ Storage::url($documents[$key]) }}" target="_blank" class="fw-medium text-primary">
+                                                    <i class="mdi mdi-eye-outline me-1"></i>Lihat Dokumen
+                                                </a>
                                             @else
-                                                <button type="button" wire:click="openDocumentModal('{{ $key }}')" class="btn btn-sm btn-outline-primary">Unggah</button>
+                                                <span class="text-muted">Belum diunggah</span>
                                             @endif
                                         </div>
                                     @endforeach


### PR DESCRIPTION
## Summary
- Remove per-document upload/change buttons in profile view
- Rely on single "Unggah Dokumen" button to manage supporting documents

## Testing
- `php artisan test` *(fails: require vendor/autoload.php missing)*
- `composer install` *(fails: GitHub API 403; credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c802867483269b963fad5fd494c9