### PR TITLE
Fix recruitment flow hover behavior and clickable interview button

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4399,6 +4399,12 @@ footer .footer-bar {
     height: 28px;
 }
 
+/* Ensure action buttons remain clickable above hover effects */
+.flow-step .btn {
+    position: relative;
+    z-index: 1;
+}
+
 .flow-step .btn-primary {
     background-color: #007bff;
     border-color: #007bff;
@@ -4436,8 +4442,6 @@ footer .footer-bar {
 .flow-step:hover {
     background-color: rgba(255, 255, 255, 0.8);
     border-radius: 6px;
-    margin: -5px;
-    padding: 5px;
 }
 
 .flow-step.active:hover {


### PR DESCRIPTION
## Summary
- prevent recruitment step boxes from shifting on hover
- ensure interview '+' action button remains clickable above hover layer

## Testing
- `composer test` *(fails: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d6e7fd308326891252a896fb7047