### PR TITLE
Enhance recruitment flow visuals with connectors and animated icons

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4317,21 +4317,34 @@ footer .footer-bar {
 }
 
 .step-icon {
-    width: 32px;
-    height: 32px;
+    width: 36px;
+    height: 36px;
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 14px;
+    font-size: 16px;
     flex-shrink: 0;
+}
+
+.step-icon.blink {
+    animation: blink 1.5s infinite;
+}
+
+@keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: .4; }
+}
+
+.flow-step.disabled .step-icon.blink {
+    animation: none;
 }
 
 .flow-connector {
     width: 2px;
-    height: 15px;
+    height: 25px;
     background: #28a745;
-    margin: 5px 0 5px 15px;
+    margin: 5px 0 5px 18px;
     display: block;
 }
 

--- a/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
+++ b/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
@@ -115,7 +115,7 @@
                                                 <div class="flow-step completed">
                                                     <div class="d-flex align-items-center justify-content-between">
                                                         <div class="d-flex align-items-center">
-                                                            <div class="step-icon bg-success text-white">
+                                                            <div class="step-icon bg-success text-white blink">
                                                                 <i class="mdi mdi-file-document-outline"></i>
                                                             </div>
                                                             <span class="ms-2 fw-medium">Lamaran Masuk</span>
@@ -131,7 +131,7 @@
                                                 <div class="flow-step {{ $interviewProgress ? 'completed' : ($currentStatus == 'pending' ? 'active' : 'disabled') }}">
                                                     <div class="d-flex align-items-center justify-content-between mb-2">
                                                         <div class="d-flex align-items-center">
-                                                            <div class="step-icon {{ $interviewProgress ? 'bg-success text-white' : ($currentStatus == 'pending' ? 'bg-primary text-white' : 'bg-light text-muted') }}">
+                                                            <div class="step-icon {{ $interviewProgress ? 'bg-success text-white' : ($currentStatus == 'pending' ? 'bg-primary text-white' : 'bg-light text-muted') }} blink">
                                                                 <i class="mdi mdi-calendar-clock"></i>
                                                             </div>
                                                             <span class="ms-2 fw-medium">Interview</span>
@@ -179,7 +179,7 @@
                                                 <div class="flow-step {{ $currentStatus == 'psikotes' ? 'completed' : ($canPsikotes && $currentStatus == 'interview' ? 'active' : 'disabled') }}">
                                                     <div class="d-flex align-items-center justify-content-between">
                                                         <div class="d-flex align-items-center">
-                                                            <div class="step-icon {{ $currentStatus == 'psikotes' ? 'bg-success text-white' : ($canPsikotes && $currentStatus == 'interview' ? 'bg-warning text-white' : 'bg-light text-muted') }}">
+                                                            <div class="step-icon {{ $currentStatus == 'psikotes' ? 'bg-success text-white' : ($canPsikotes && $currentStatus == 'interview' ? 'bg-warning text-white' : 'bg-light text-muted') }} blink">
                                                                 <i class="mdi mdi-brain"></i>
                                                             </div>
                                                             <span class="ms-2 fw-medium">Psikotes</span>
@@ -203,7 +203,7 @@
                                                 <div class="flow-step {{ $isCompleted ? 'completed' : ($currentStatus == 'psikotes' ? 'active' : 'disabled') }}">
                                                     <div class="d-flex align-items-center justify-content-between">
                                                         <div class="d-flex align-items-center">
-                                                            <div class="step-icon {{ $currentStatus == 'diterima' ? 'bg-success' : ($currentStatus == 'ditolak' ? 'bg-danger' : ($currentStatus == 'psikotes' ? 'bg-info' : 'bg-light')) }} {{ $isCompleted || $currentStatus == 'psikotes' ? 'text-white' : 'text-muted' }}">
+                                                            <div class="step-icon {{ $currentStatus == 'diterima' ? 'bg-success' : ($currentStatus == 'ditolak' ? 'bg-danger' : ($currentStatus == 'psikotes' ? 'bg-info' : 'bg-light')) }} {{ $isCompleted || $currentStatus == 'psikotes' ? 'text-white' : 'text-muted' }} blink">
                                                                 <i class="mdi {{ $currentStatus == 'diterima' ? 'mdi-check-circle' : ($currentStatus == 'ditolak' ? 'mdi-close-circle' : 'mdi-gavel') }}"></i>
                                                             </div>
                                                             <span class="ms-2 fw-medium">Keputusan</span>


### PR DESCRIPTION
## Summary
- Add blinking animation and larger icons for recruitment steps
- Extend vertical connectors for clearer Lamaran Masuk → Keputusan flow

## Testing
- `composer test` *(fails: Failed to open vendor/autoload.php)*
- `composer install --no-interaction` *(fails: unable to access github.com, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e91df2188326ad16c5201f7248ec