### PR TITLE
Fix interview scheduling button and highlight active step

### DIFF
--- a/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
+++ b/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
@@ -116,7 +116,7 @@
                                                 <div class="flow-step completed">
                                                     <div class="d-flex align-items-center justify-content-between">
                                                         <div class="d-flex align-items-center">
-                                                            <div class="step-icon bg-success text-white blink">
+                                                            <div class="step-icon bg-success text-white">
                                                                 <i class="mdi mdi-file-document-outline"></i>
                                                             </div>
                                                             <span class="ms-2 fw-medium">Lamaran Masuk</span>
@@ -132,14 +132,14 @@
                                                 <div class="flow-step {{ $interviewProgress ? 'completed' : ($currentStatus == 'pending' ? 'active' : 'disabled') }}">
                                                     <div class="d-flex align-items-center justify-content-between mb-2">
                                                         <div class="d-flex align-items-center">
-                                                            <div class="step-icon {{ $interviewProgress ? 'bg-success text-white' : ($currentStatus == 'pending' ? 'bg-primary text-white' : 'bg-light text-muted') }} blink">
+                                                            <div class="step-icon {{ $interviewProgress ? 'bg-success text-white' : ($currentStatus == 'pending' ? 'bg-primary text-white' : 'bg-light text-muted') }} {{ !$interviewProgress && $currentStatus == 'pending' ? 'blink' : '' }}">
                                                                 <i class="mdi mdi-calendar-clock"></i>
                                                             </div>
                                                             <span class="ms-2 fw-medium">Interview</span>
                                                         </div>
                                                         @if(!$interviewProgress && $currentStatus == 'pending' && !$isRecruiter)
-                                                            <button type="button" class="btn btn-primary btn-sm" 
-                                                                    wire:click.prevent="prepareInterview({{ $lamaran->id }})"
+                                                            <button type="button" class="btn btn-primary btn-sm"
+                                                                    wire:click="prepareInterview({{ $lamaran->id }})"
                                                                     title="Jadwalkan Interview">
                                                                 <i class="mdi mdi-plus"></i>
                                                             </button>
@@ -180,13 +180,13 @@
                                                 <div class="flow-step {{ $currentStatus == 'psikotes' ? 'completed' : ($canPsikotes && $currentStatus == 'interview' ? 'active' : 'disabled') }}">
                                                     <div class="d-flex align-items-center justify-content-between">
                                                         <div class="d-flex align-items-center">
-                                                            <div class="step-icon {{ $currentStatus == 'psikotes' ? 'bg-success text-white' : ($canPsikotes && $currentStatus == 'interview' ? 'bg-warning text-white' : 'bg-light text-muted') }} blink">
+                                                            <div class="step-icon {{ $currentStatus == 'psikotes' ? 'bg-success text-white' : ($canPsikotes && $currentStatus == 'interview' ? 'bg-warning text-white' : 'bg-light text-muted') }} {{ $canPsikotes && $currentStatus == 'interview' ? 'blink' : '' }}">
                                                                 <i class="mdi mdi-brain"></i>
                                                             </div>
                                                             <span class="ms-2 fw-medium">Psikotes</span>
                                                         </div>
                                                         @if($canPsikotes && $currentStatus == 'interview' && !$isRecruiter && !$isCompleted)
-                                                            <button type="button" class="btn btn-warning btn-sm" 
+                                                            <button type="button" class="btn btn-warning btn-sm"
                                                                     wire:click.prevent="setStatus({{ $lamaran->id }}, 'psikotes')"
                                                                     title="Lanjut ke Psikotes">
                                                                 <i class="mdi mdi-arrow-right"></i>
@@ -204,7 +204,7 @@
                                                 <div class="flow-step {{ $isCompleted ? 'completed' : ($currentStatus == 'psikotes' ? 'active' : 'disabled') }}">
                                                     <div class="d-flex align-items-center justify-content-between">
                                                         <div class="d-flex align-items-center">
-                                                            <div class="step-icon {{ $currentStatus == 'diterima' ? 'bg-success' : ($currentStatus == 'ditolak' ? 'bg-danger' : ($currentStatus == 'psikotes' ? 'bg-info' : 'bg-light')) }} {{ $isCompleted || $currentStatus == 'psikotes' ? 'text-white' : 'text-muted' }} blink">
+                                                            <div class="step-icon {{ $currentStatus == 'diterima' ? 'bg-success' : ($currentStatus == 'ditolak' ? 'bg-danger' : ($currentStatus == 'psikotes' ? 'bg-info' : 'bg-light')) }} {{ $isCompleted || $currentStatus == 'psikotes' ? 'text-white' : 'text-muted' }} {{ !$isCompleted && $currentStatus == 'psikotes' ? 'blink' : '' }}">
                                                                 <i class="mdi {{ $currentStatus == 'diterima' ? 'mdi-check-circle' : ($currentStatus == 'ditolak' ? 'mdi-close-circle' : 'mdi-gavel') }}"></i>
                                                             </div>
                                                             <span class="ms-2 fw-medium">Keputusan</span>


### PR DESCRIPTION
## Summary
- Ensure only the active recruitment step blinks
- Fix interview schedule button to correctly open the modal

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eb9f3e8c8326a0190cb7ae55ab0a