### PR TITLE
Add search functionality for interview schedule

### DIFF
--- a/app/Livewire/Officer/InterviewSchedule/Index.php
+++ b/app/Livewire/Officer/InterviewSchedule/Index.php
@@ -17,20 +17,36 @@ class Index extends Component
     public $resultCatatan;
     public $resultDokumen;
 
+    public $search = '';
+
     protected $listeners = ['refreshSchedule' => '$refresh'];
 
     public function render()
     {
-        $interviews = ProgressRekrutmen::with(['lamarlowongan.kandidat.user'])
+        $interviews = ProgressRekrutmen::with(['lamarlowongan.kandidat.user', 'lamarlowongan.lowongan'])
             ->where('status', 'interview')
             ->where('officer_id', auth()->id())
             ->where('is_interview', true)
+            ->when($this->search, function ($q) {
+                $q->where(function ($query) {
+                    $query->whereHas('lamarlowongan.lowongan', function ($qq) {
+                        $qq->where('nama_posisi', 'like', '%' . $this->search . '%');
+                    })->orWhereHas('lamarlowongan.kandidat.user', function ($qq) {
+                        $qq->where('name', 'like', '%' . $this->search . '%');
+                    });
+                });
+            })
             ->orderBy('waktu_pelaksanaan')
             ->paginate(10);
 
         return view('livewire.officer.interview-schedule.index', [
             'interviews' => $interviews,
         ]);
+    }
+
+    public function updatingSearch()
+    {
+        $this->resetPage();
     }
 
     public function openResultModal($progressId)

--- a/resources/views/livewire/officer/interview-schedule/index.blade.php
+++ b/resources/views/livewire/officer/interview-schedule/index.blade.php
@@ -33,9 +33,13 @@
     <section class="section">
         <div class="container">
             <div class="row mb-4">
-                <div class="col-12">
-                    <h6 class="mb-1">Daftar Jadwal Interview</h6>
-                    <p class="text-muted mb-0">Kelola hasil interview kandidat Anda.</p>
+                <div class="col-md-6">
+                    <div class="input-group">
+                        <input type="text" class="form-control" placeholder="Cari kandidat atau posisi..." wire:model.live="search">
+                        <button class="btn btn-primary" type="button">
+                            <i class="mdi mdi-magnify"></i>
+                        </button>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add candidate/position search field to interview schedule view
- support search filtering in interview schedule Livewire component

## Testing
- `composer test` *(fails: vendor autoload not found)*
- `composer install` *(fails: requires GitHub token to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a826f3c3688326a487c8a3f610b962