### PR TITLE
style: match bank-soal action buttons to kandidat view

### DIFF
--- a/resources/views/livewire/bank-soal/index.blade.php
+++ b/resources/views/livewire/bank-soal/index.blade.php
@@ -109,11 +109,13 @@
                                                     {{ $soal->status ? 'Aktif' : 'Nonaktif' }}
                                                 </span>
                                             </td>
-                                            <td class="p-3 text-center">
-                                                <div class="btn-group" role="group">
-                                                    <button wire:click="edit({{ $soal->id_soal }})" class="btn btn-sm btn-soft-primary"><i class="mdi mdi-pencil"></i></button>
-                                                    <button wire:click="delete({{ $soal->id_soal }})" wire:confirm="Anda yakin ingin menghapus soal ini?" class="btn btn-sm btn-soft-danger"><i class="mdi mdi-trash-can-outline"></i></button>
-                                                </div>
+                                            <td class="p-3">
+                                                <button wire:click="edit({{ $soal->id_soal }})" class="btn btn-sm btn-soft-warning me-1">
+                                                    <i class="mdi mdi-pencil"></i>
+                                                </button>
+                                                <button wire:click="delete({{ $soal->id_soal }})" wire:confirm="Anda yakin ingin menghapus soal ini?" class="btn btn-sm btn-soft-danger">
+                                                    <i class="mdi mdi-trash-can-outline"></i>
+                                                </button>
                                             </td>
                                         </tr>
                                         @empty


### PR DESCRIPTION
## Summary
- restyle bank-soal action buttons to align spacing and color with kandidat view

## Testing
- `phpunit` *(fails: command not found)*
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a829ee71d08326b93b4704732c5812