### PR TITLE
Hide interview results from candidates

### DIFF
--- a/app/Livewire/Officer/LamaranLowongan/Index.php
+++ b/app/Livewire/Officer/LamaranLowongan/Index.php
@@ -6,6 +6,7 @@ use Livewire\Component;
 use Livewire\WithPagination;
 use App\Models\LamarLowongan;
 use App\Models\User;
+use App\Models\ProgressRekrutmen;
 use Illuminate\Support\Facades\Log;
 
 class Index extends Component
@@ -28,6 +29,11 @@ class Index extends Component
     public $detailModal = false;
     public $selectedKandidat;
     public $documents = [];
+
+    // hasil interview
+    public $resultModal = false;
+    public $resultCatatan;
+    public $resultDokumen;
 
 
     public function mount()
@@ -174,4 +180,18 @@ class Index extends Component
         $this->documents = [];
     }
 
+    public function openResult($progressId)
+    {
+        $progress = ProgressRekrutmen::findOrFail($progressId);
+        $this->resultCatatan = $progress->catatan;
+        $this->resultDokumen = $progress->dokumen_pendukung;
+        $this->resultModal = true;
+    }
+
+    public function closeResultModal()
+    {
+        $this->resultModal = false;
+        $this->resultCatatan = null;
+        $this->resultDokumen = null;
+    }
 }

--- a/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
+++ b/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
@@ -207,14 +207,6 @@
                                                                 <i class="mdi mdi-video me-1"></i>Join Zoom
                                                             </a>
                                                         @endif
-                                                    @if($latestInterview->catatan)
-                                                        <div class="mt-2"><strong>Catatan:</strong> {{ $latestInterview->catatan }}</div>
-                                                    @endif
-                                                    @if($latestInterview->dokumen_pendukung)
-                                                        <div class="mt-1">
-                                                            <a href="{{ Storage::url($latestInterview->dokumen_pendukung) }}" target="_blank">Dokumen Pendukung</a>
-                                                        </div>
-                                                    @endif
                                                 </div>
                                             @endif
                                             @if($showCbtLink)

--- a/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
+++ b/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
@@ -144,10 +144,16 @@
                                                                             <div class="text-muted">Interviewer:</div>
                                                                             <div class="fw-medium">{{ optional($interviewProgress->officer)->name }}</div>
                                                                         </div>
-                                                                        <a href="{{ $interviewProgress->link_zoom }}" target="_blank" 
-                                                                           class="btn btn-outline-primary btn-sm">
-                                                                            <i class="mdi mdi-video me-1"></i> Zoom
-                                                                        </a>
+                                                                        @if($interviewProgress->catatan || $interviewProgress->dokumen_pendukung)
+                                                                            <button type="button" class="btn btn-outline-primary btn-sm" wire:click="openResult({{ $interviewProgress->id }})">
+                                                                                <i class="mdi mdi-file-document me-1"></i> Lihat Hasil
+                                                                            </button>
+                                                                        @else
+                                                                            <a href="{{ $interviewProgress->link_zoom }}" target="_blank"
+                                                                               class="btn btn-outline-primary btn-sm">
+                                                                                <i class="mdi mdi-video me-1"></i> Zoom
+                                                                            </a>
+                                                                        @endif
                                                                     </div>
                                                                     @if($interviewProgress->waktu_pelaksanaan)
                                                                         <div class="text-muted mt-1">
@@ -375,6 +381,29 @@
                             @endforeach
                         </div>
                     @endif
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal Hasil Interview -->
+    <div class="modal fade @if($resultModal) show @endif" tabindex="-1" style="@if($resultModal) display:block; @endif">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Hasil Interview</h5>
+                    <button type="button" class="btn-close" wire:click="closeResultModal"></button>
+                </div>
+                <div class="modal-body">
+                    @if($resultCatatan)
+                        <p>{{ $resultCatatan }}</p>
+                    @endif
+                    @if($resultDokumen)
+                        <a href="{{ Storage::url($resultDokumen) }}" target="_blank">Dokumen Pendukung</a>
+                    @endif
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" wire:click="closeResultModal">Tutup</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Remove interview result notes and documents from candidate application view
- Show uploaded interview results in officer application view with a modal
- Support viewing interview results in officer lamaran-lowongan component

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install --no-interaction` *(fails: requires GitHub token, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa07d856fc8326bb3dd14561869182