### PR TITLE
Store interview result documents in progress records

### DIFF
--- a/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
+++ b/resources/views/livewire/officer/lamaran-lowongan/index.blade.php
@@ -399,7 +399,7 @@
                         <p>{{ $resultCatatan }}</p>
                     @endif
                     @if($resultDokumen)
-                        <a href="{{ Storage::url($resultDokumen) }}" target="_blank">Dokumen Pendukung</a>
+                        <a href="{{ asset('storage/' . $resultDokumen) }}" target="_blank">Dokumen Pendukung</a>
                     @endif
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
## Summary
- Save uploaded interview result documents directly to `progress_rekrutmen` records and clean up old files
- Display supporting documents in application view using public storage path

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0e32e0048326939afa43f1141b4c