### PR TITLE
Fix undefined Soal relationships in CBT test

### DIFF
--- a/app/Livewire/Cbt/Test.php
+++ b/app/Livewire/Cbt/Test.php
@@ -54,7 +54,6 @@ class Test extends Component
     public function initializeNewTest()
     {
         $this->questions = Soal::where('status', true)
-            ->with(['typeSoal', 'typeJawaban']) // eager load relationships
             ->inRandomOrder()
             ->take($this->maxQuestions)
             ->get();


### PR DESCRIPTION
## Summary
- avoid eager loading non-existent `typeSoal` and `typeJawaban` relationships when initializing CBT test questions

## Testing
- `php artisan test` *(fails: require(/workspace/jobportal/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: curl error 56 - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa12cb1f048326a6492bb9a85cfd2e