### PR TITLE
Add psychotest listing page for candidates

### DIFF
--- a/app/Livewire/Cbt/Index.php
+++ b/app/Livewire/Cbt/Index.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Livewire\Cbt;
+
+use Livewire\Component;
+use Illuminate\Support\Facades\Auth;
+
+class Index extends Component
+{
+    public $lamarans;
+
+    public function mount()
+    {
+        $user = Auth::user();
+        $kandidat = $user->kandidat ?? null;
+
+        $this->lamarans = collect();
+
+        if ($kandidat) {
+            $this->lamarans = $kandidat->lamarLowongans()
+                ->whereHas('progressRekrutmen', function ($q) {
+                    $q->where('status', 'psikotes')
+                      ->where('is_psikotes', true);
+                })
+                ->with('lowongan')
+                ->get();
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.cbt.index');
+    }
+}
+

--- a/resources/views/livewire/cbt/index.blade.php
+++ b/resources/views/livewire/cbt/index.blade.php
@@ -1,0 +1,58 @@
+<div>
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12">
+                    <div class="title-heading text-center">
+                        <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">Tes Seleksi</h5>
+                    </div>
+                </div>
+            </div>
+            <div class="position-middle-bottom">
+                <nav aria-label="breadcrumb" class="d-block">
+                    <ul class="breadcrumb breadcrumb-muted mb-0 p-0">
+                        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">Dashboard</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">Tes Seleksi</li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </section>
+
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-8">
+                    <h4 class="mb-4 text-center">Daftar Psikotes</h4>
+
+                    @forelse($lamarans as $lamaran)
+                        <div class="card shadow-sm mb-3">
+                            <div class="card-body d-flex justify-content-between align-items-center">
+                                <div>
+                                    <h5 class="mb-1">{{ $lamaran->lowongan->nama_posisi }}</h5>
+                                    <p class="mb-0 text-muted">{{ $lamaran->lowongan->departemen }} - {{ $lamaran->lowongan->lokasi_penugasan }}</p>
+                                </div>
+                                <a href="{{ route('cbt.test') }}" target="_blank" class="btn btn-primary btn-sm">
+                                    <i class="mdi mdi-pencil me-1"></i>Mulai Psikotes
+                                </a>
+                            </div>
+                        </div>
+                    @empty
+                        <div class="alert alert-info text-center" role="alert">
+                            Belum ada tes psikotes yang tersedia untuk Anda.
+                        </div>
+                    @endforelse
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/resources/views/livewire/kandidat/dashboard.blade.php
+++ b/resources/views/livewire/kandidat/dashboard.blade.php
@@ -56,7 +56,7 @@
                             <h5 class="fw-bold">Tes Seleksi</h5>
                             <p class="text-muted">Kerjakan tes seleksi yang tersedia untuk melanjutkan proses rekrutmen.</p>
                             @auth
-                                <a href="#" class="read-more">Mulai Tes <i class="mdi mdi-arrow-right"></i></a>
+                                <a href="{{ route('cbt.index') }}" class="read-more">Mulai Tes <i class="mdi mdi-arrow-right"></i></a>
                             @else
                                 <a href="javascript:void(0)" onclick="promptAuth()" class="read-more">Mulai Tes <i class="mdi mdi-arrow-right"></i></a>
                             @endauth

--- a/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
+++ b/resources/views/livewire/kandidat/lowongan-dilamar/index.blade.php
@@ -211,7 +211,7 @@
                                             @endif
                                             @if($showCbtLink)
                                                 <div class="mt-2">
-                                                    <a href="{{ route('cbt.test') }}" target="_blank" class="btn btn-sm btn-outline-primary">
+                                                    <a href="{{ route('cbt.index') }}" class="btn btn-sm btn-outline-primary">
                                                         <i class="mdi mdi-pencil me-1"></i>Mulai Psikotes
                                                     </a>
                                                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -69,6 +69,7 @@ Route::middleware([
     Route::get('/lowongan-dilamar', App\Livewire\Kandidat\LowonganDilamar\Index::class)->name('kandidat.lowongan-dilamar');
     Route::get('/kandidat/lowongan-dilamar', App\Livewire\Kandidat\LowonganDilamar\Index::class)
         ->name('kandidat.lowongan-dilamar');
+    Route::get('/cbt', App\Livewire\Cbt\Index::class)->name('cbt.index');
     Route::get('/cbt/test', App\Livewire\Cbt\Test::class)->name('cbt.test');
     Route::get('/profile', App\Livewire\Profile\ShowProfile::class)->name('profile.show');
     Route::get('/profile/edit', App\Livewire\Profile\UpdateKandidatProfileForm::class)->name('profile.edit');


### PR DESCRIPTION
## Summary
- add Livewire component and view to list psychotest-ready applications
- link dashboard and applications page to new psychotest list
- register route for candidate psychotest page

## Testing
- ⚠️ `php artisan test` *(missing composer dependencies, install failed due to GitHub access)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1750f9b08326ac1a4fa084b15b04