### PR TITLE
feat: enhance browse jobs view

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Lowongan;
 
 class JobController extends Controller
 {
@@ -13,6 +14,7 @@ class JobController extends Controller
 
     public function browse()
     {
-        return view('jobs.browse');
+        $jobs = Lowongan::with('kategoriLowongan')->latest()->get();
+        return view('jobs.browse', compact('jobs'));
     }
 }

--- a/resources/views/jobs/browse.blade.php
+++ b/resources/views/jobs/browse.blade.php
@@ -5,8 +5,36 @@
 
     <!-- Main Content -->
     <div class="main-content">
-        <!-- Render the Livewire job browser component -->
-        <livewire:lowongan.list-with-detail />
+        <section class="py-5 bg-light">
+            <div class="container">
+                <h3 class="text-center mb-4">Available Jobs</h3>
+                <div class="row">
+                    @forelse($jobs as $job)
+                        <div class="col-lg-4 col-md-6 mb-4">
+                            <div class="card h-100 shadow-sm">
+                                @if($job->foto)
+                                    <img src="{{ asset('storage/image/lowongan/' . $job->foto) }}" class="card-img-top" alt="{{ $job->nama_posisi }}">
+                                @else
+                                    <img src="{{ asset('images/error.png') }}" class="card-img-top" alt="{{ $job->nama_posisi }}">
+                                @endif
+                                <div class="card-body d-flex flex-column">
+                                    <h5 class="card-title">{{ $job->nama_posisi }}</h5>
+                                    <p class="text-muted mb-1">{{ $job->kategoriLowongan->nama_kategori ?? 'Uncategorized' }}</p>
+                                    <p class="text-muted mb-1"><i data-feather="map-pin" class="align-text-bottom me-1"></i>{{ $job->lokasi_penugasan }} - {{ $job->is_remote ? 'Remote' : 'On-site' }}</p>
+                                    <p class="text-muted mb-2"><i data-feather="dollar-sign" class="align-text-bottom me-1"></i>{{ $job->formatted_gaji }}</p>
+                                    <p class="card-text flex-grow-1">{{ \Illuminate\Support\Str::limit($job->deskripsi, 120) }}</p>
+                                    <a href="{{ route('login', ['redirect' => url()->current(), 'job_id' => $job->id]) }}" class="btn btn-primary mt-auto">Apply Now</a>
+                                </div>
+                            </div>
+                        </div>
+                    @empty
+                        <div class="col-12">
+                            <div class="alert alert-info text-center">No jobs available at the moment.</div>
+                        </div>
+                    @endforelse
+                </div>
+            </div>
+        </section>
     </div>
 
     @include('partials.footer')
@@ -23,6 +51,8 @@
     <!-- Custom -->
     <script src="{{ asset('js/plugins.init.js') }}"></script>
     <script src="{{ asset('js/app.js') }}"></script>
-    @livewireScripts
+    <script>
+        if(window.feather) feather.replace();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display list of jobs with images and details on the browse page
- load jobs in controller and remove livewire dependency

## Testing
- `php -d memory_limit=512M vendor/bin/phpunit` (fails: Could not open input file: vendor/bin/phpunit)

------
https://chatgpt.com/codex/tasks/task_e_68aa1f68425083268494a65622b11d67