### PR TITLE
Add create vacancy button

### DIFF
--- a/resources/views/livewire/lowongan/index.blade.php
+++ b/resources/views/livewire/lowongan/index.blade.php
@@ -65,6 +65,9 @@
                     <div class="card border-0 rounded shadow">
                         <!-- Filter Form -->
                         <div class="m-4">
+                            <div class="d-flex justify-content-end mb-3">
+                                <a href="{{ route('Lowongan.Create') }}" class="btn btn-primary btn-sm">{{ __('Add Job Vacancy') }}</a>
+                            </div>
                             <div class="row g-2">
                                 <div class="col-md-2">
                                     <select wire:model.live="statusFilter" class="form-select">


### PR DESCRIPTION
## Summary
- add button on lowongan index page for creating new job vacancy

## Testing
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*
- `npm test` *(fails: Missing script: "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68ae586ce4908326a882bf0335bfd0f8