### PR TITLE
Add basic export utilities and Bank Soal navigation

### DIFF
--- a/app/Livewire/BankSoal/Index.php
+++ b/app/Livewire/BankSoal/Index.php
@@ -8,10 +8,11 @@ use App\Models\KategoriSoal;
 use Livewire\WithPagination;
 use Livewire\WithFileUploads;
 use Illuminate\Support\Facades\Storage;
+use App\Traits\Exportable;
 
 class Index extends Component
 {
-    use WithPagination, WithFileUploads;
+    use WithPagination, WithFileUploads, Exportable;
 
     protected $paginationTheme = 'bootstrap';
 
@@ -222,6 +223,31 @@ class Index extends Component
 
         $soal->delete();
         session()->flash('message', 'Soal berhasil dihapus.');
+    }
+
+    public function exportExcel()
+    {
+        $rows = Soal::with('kategori')->get()->map(function ($s) {
+            return [
+                $s->soal,
+                $s->kategori->nama_kategori,
+                $s->pilihan_1,
+                $s->pilihan_2,
+                $s->pilihan_3,
+                $s->pilihan_4,
+                $s->jawaban,
+                $s->status ? 'Aktif' : 'Nonaktif',
+            ];
+        });
+
+        $headings = ['Soal','Kategori','Pilihan 1','Pilihan 2','Pilihan 3','Pilihan 4','Jawaban','Status'];
+        return $this->downloadCsv('bank-soal.csv', $headings, $rows);
+    }
+
+    public function exportPdf()
+    {
+        $soals = Soal::with('kategori')->get();
+        return $this->downloadPdf('bank-soal.pdf', 'exports.bank-soal', ['soals' => $soals]);
     }
 
     private function resetForm()

--- a/app/Traits/Exportable.php
+++ b/app/Traits/Exportable.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Collection;
+
+trait Exportable
+{
+    public function downloadCsv(string $filename, array $headings, Collection $rows)
+    {
+        $headers = [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => "attachment; filename={$filename}",
+        ];
+
+        $callback = function () use ($headings, $rows) {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, $headings);
+            foreach ($rows as $row) {
+                fputcsv($handle, $row);
+            }
+            fclose($handle);
+        };
+
+        return response()->stream($callback, 200, $headers);
+    }
+
+    public function downloadPdf(string $filename, string $view, array $data = [])
+    {
+        // Placeholder implementation; integrate PDF library as needed
+        $headers = [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => "attachment; filename={$filename}",
+        ];
+
+        $html = view($view, $data)->render();
+        $callback = function () use ($html) {
+            // This is a placeholder; real PDF generation requires a dedicated library
+            echo $html;
+        };
+
+        return response()->stream($callback, 200, $headers);
+    }
+}
+

--- a/resources/views/exports/bank-soal.blade.php
+++ b/resources/views/exports/bank-soal.blade.php
@@ -1,0 +1,28 @@
+<table>
+    <thead>
+        <tr>
+            <th>Soal</th>
+            <th>Kategori</th>
+            <th>Pilihan 1</th>
+            <th>Pilihan 2</th>
+            <th>Pilihan 3</th>
+            <th>Pilihan 4</th>
+            <th>Jawaban</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($soals as $soal)
+        <tr>
+            <td>{{ $soal->soal }}</td>
+            <td>{{ $soal->kategori->nama_kategori }}</td>
+            <td>{{ $soal->pilihan_1 }}</td>
+            <td>{{ $soal->pilihan_2 }}</td>
+            <td>{{ $soal->pilihan_3 }}</td>
+            <td>{{ $soal->pilihan_4 }}</td>
+            <td>{{ $soal->jawaban }}</td>
+            <td>{{ $soal->status ? 'Aktif' : 'Nonaktif' }}</td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>

--- a/resources/views/livewire/bank-soal/index.blade.php
+++ b/resources/views/livewire/bank-soal/index.blade.php
@@ -58,9 +58,17 @@
                     </div>
                 </div>
                 <div class="col-md-6 text-md-end mt-3 mt-md-0">
-                    <button wire:click="create" class="btn btn-primary">
-                        <i class="mdi mdi-plus-circle-outline me-1"></i> Tambah Soal
-                    </button>
+                    <div class="btn-group" role="group">
+                        <button wire:click="exportExcel" type="button" class="btn btn-soft-success">
+                            <i class="mdi mdi-file-excel-outline me-1"></i> Export Excel
+                        </button>
+                        <button wire:click="exportPdf" type="button" class="btn btn-soft-danger">
+                            <i class="mdi mdi-file-pdf-box me-1"></i> Export PDF
+                        </button>
+                        <button wire:click="create" class="btn btn-primary">
+                            <i class="mdi mdi-plus-circle-outline me-1"></i> Tambah Soal
+                        </button>
+                    </div>
                 </div>
             </div>
 

--- a/resources/views/partials/navbar-menu.blade.php
+++ b/resources/views/partials/navbar-menu.blade.php
@@ -9,12 +9,16 @@
             <li><a href="{{ route('kandidat.lowongan-dilamar') }}" class="{{ request()->routeIs('kandidat.lowongan-dilamar') ? 'active' : '' }}">{{ __('Lamaran Saya') }}</a></li>
             <li><a href="{{ route('profile.show') }}" class="{{ request()->routeIs('profile.*') ? 'active' : '' }}">{{ __('Profil') }}</a></li>
         @elseif($role === 'officer')
+            @php $jabatan = strtolower(optional(auth()->user()->officer)->jabatan); @endphp
             <li><a href="{{ route('officers.index') }}" class="{{ request()->routeIs('officers.index') ? 'active' : '' }}">{{ __('Officers') }}</a></li>
             <li><a href="{{ route('kategori-lowongan.Index') }}" class="{{ request()->routeIs('kategori-lowongan.*') ? 'active' : '' }}">{{ __('Kategori Lowongan') }}</a></li>
             <li><a href="{{ route('Lowongan.Index') }}" class="{{ request()->routeIs('Lowongan.*') ? 'active' : '' }}">{{ __('Lowongan') }}</a></li>
             <li><a href="{{ route('lamaran-lowongan.index') }}" class="{{ request()->routeIs('lamaran-lowongan.index') ? 'active' : '' }}">{{ __('Lamaran') }}</a></li>
             <li><a href="{{ route('jadwal-interview.index') }}" class="{{ request()->routeIs('jadwal-interview.index') ? 'active' : '' }}">{{ __('Jadwal Interview') }}</a></li>
             <li><a href="{{ route('test-results.index') }}" class="{{ request()->routeIs('test-results.*') ? 'active' : '' }}">{{ __('Hasil Test CBT') }}</a></li>
+            @if(in_array($jabatan, ['manager','coordinator']))
+                <li><a href="{{ route('bank-soal.index') }}" class="{{ request()->routeIs('bank-soal.*') ? 'active' : '' }}">{{ __('Bank Soal') }}</a></li>
+            @endif
         @else
             <li><a href="{{ route('dashboard') }}" class="{{ request()->routeIs('dashboard') ? 'active' : '' }}">{{ __('Home') }}</a></li>
             <li><a href="{{ route('jobs.browse') }}" class="{{ request()->routeIs('jobs.*') ? 'active' : '' }}">{{ __('Jobs') }}</a></li>


### PR DESCRIPTION
## Summary
- add generic Exportable trait to stream CSV or placeholder PDF responses
- enable Bank Soal component to export all question data and show export buttons
- show Bank Soal link in navbar for manager and coordinator officers

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68ae7fbbd35883269e705f0754a873df