### PR TITLE
Ensure UTF-8 encoding before generating PDFs

### DIFF
--- a/app/Traits/Exportable.php
+++ b/app/Traits/Exportable.php
@@ -29,6 +29,9 @@ trait Exportable
     {
         $html = view($view, $data)->render();
 
+        // Ensure the rendered HTML is valid UTF-8 to prevent "Malformed UTF-8" errors
+        $html = mb_convert_encoding($html, 'UTF-8', 'UTF-8');
+
         if (class_exists(\Barryvdh\DomPDF\Facade\Pdf::class)) {
             $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadHTML($html);
             return $pdf->download($filename);


### PR DESCRIPTION
## Summary
- sanitize rendered HTML using UTF-8 conversion before creating PDFs

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68aea160518083269c114bd407893173