### PR TITLE
Add PDF export for officer modules using DomPDF

### DIFF
--- a/app/Livewire/Officer/LamaranLowongan/Index.php
+++ b/app/Livewire/Officer/LamaranLowongan/Index.php
@@ -8,10 +8,11 @@ use App\Models\LamarLowongan;
 use App\Models\User;
 use App\Models\ProgressRekrutmen;
 use Illuminate\Support\Facades\Log;
+use App\Traits\Exportable;
 
 class Index extends Component
 {
-    use WithPagination;
+    use WithPagination, Exportable;
 
     public $search = '';
 
@@ -193,5 +194,25 @@ class Index extends Component
         $this->resultModal = false;
         $this->resultCatatan = null;
         $this->resultDokumen = null;
+    }
+
+    public function exportPdf()
+    {
+        $lamarans = LamarLowongan::with(['kandidat.user', 'lowongan'])
+            ->when($this->search, function ($q) {
+                $q->where(function ($query) {
+                    $query->whereHas('lowongan', function ($qq) {
+                        $qq->where('nama_posisi', 'like', '%' . $this->search . '%');
+                    })->orWhereHas('kandidat.user', function ($qq) {
+                        $qq->where('name', 'like', '%' . $this->search . '%');
+                    });
+                });
+            })
+            ->latest()
+            ->get();
+
+        return $this->downloadPdf('lamaran-lowongan.pdf', 'exports.lamaran-lowongan', [
+            'lamaranList' => $lamarans,
+        ]);
     }
 }

--- a/resources/views/exports/interview-schedule.blade.php
+++ b/resources/views/exports/interview-schedule.blade.php
@@ -1,0 +1,20 @@
+<table>
+    <thead>
+        <tr>
+            <th>Kandidat</th>
+            <th>Posisi</th>
+            <th>Waktu Pelaksanaan</th>
+            <th>Link Zoom</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($interviews as $interview)
+        <tr>
+            <td>{{ optional($interview->lamarlowongan->kandidat->user)->name }}</td>
+            <td>{{ optional($interview->lamarlowongan->lowongan)->nama_posisi }}</td>
+            <td>{{ optional($interview->waktu_pelaksanaan)->format('Y-m-d H:i') }}</td>
+            <td>{{ $interview->link_zoom }}</td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>

--- a/resources/views/exports/lamaran-lowongan.blade.php
+++ b/resources/views/exports/lamaran-lowongan.blade.php
@@ -1,0 +1,20 @@
+<table>
+    <thead>
+        <tr>
+            <th>Kandidat</th>
+            <th>Email</th>
+            <th>Posisi</th>
+            <th>Tanggal Lamar</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($lamaranList as $lamaran)
+        <tr>
+            <td>{{ optional($lamaran->kandidat->user)->name }}</td>
+            <td>{{ optional($lamaran->kandidat->user)->email }}</td>
+            <td>{{ optional($lamaran->lowongan)->nama_posisi }}</td>
+            <td>{{ optional($lamaran->created_at)->format('Y-m-d') }}</td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>

--- a/resources/views/exports/test-results.blade.php
+++ b/resources/views/exports/test-results.blade.php
@@ -1,0 +1,26 @@
+<table>
+    <thead>
+        <tr>
+            <th>Nama Kandidat</th>
+            <th>Nilai</th>
+            <th>Status</th>
+            <th>Jawaban Benar</th>
+            <th>Total Soal</th>
+            <th>Waktu Mulai</th>
+            <th>Selesai</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($results as $result)
+        <tr>
+            <td>{{ $result->user->name }}</td>
+            <td>{{ $result->score }}</td>
+            <td>{{ $result->score >= 70 ? 'Lulus' : 'Tidak Lulus' }}</td>
+            <td>{{ $result->correct_answers }}</td>
+            <td>{{ $result->total_questions }}</td>
+            <td>{{ optional($result->started_at)->format('Y-m-d H:i') }}</td>
+            <td>{{ optional($result->completed_at)->format('Y-m-d H:i') }}</td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>

--- a/resources/views/livewire/officer/test-results/index.blade.php
+++ b/resources/views/livewire/officer/test-results/index.blade.php
@@ -25,9 +25,9 @@
                                 <div class="col-md-4">
                                     <div class="position-relative">
                                         <i class="mdi mdi-magnify position-absolute top-50 start-0 translate-middle-y ms-2 text-muted"></i>
-                                        <input type="text" 
-                                               wire:model.live.debounce.300ms="search" 
-                                               class="form-control ps-5" 
+                                        <input type="text"
+                                               wire:model.live.debounce.300ms="search"
+                                               class="form-control ps-5"
                                                placeholder="Cari berdasarkan nama atau email...">
                                     </div>
                                 </div>
@@ -45,6 +45,14 @@
                                             <option value="asc">Menaik</option>
                                         </select>
                                     </div>
+                                </div>
+                            </div>
+
+                            <div class="row mb-4">
+                                <div class="col-12 text-end">
+                                    <button wire:click="exportPdf" class="btn btn-outline-primary">
+                                        <i class="mdi mdi-file-pdf-box"></i> Export PDF
+                                    </button>
                                 </div>
                             </div>
 


### PR DESCRIPTION
## Summary
- enable PDF download for officer job applications using DomPDF
- add interview schedule PDF export
- allow exporting test results to PDF with UI button

## Testing
- `php artisan test` *(fails: Failed to open required '/workspace/jobportal/vendor/autoload.php')*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aed0ed7e3c8326b4f495344fe8a8e6