### PR TITLE
Add officer profile page with password reset

### DIFF
--- a/app/Livewire/Officer/Profile/ShowProfile.php
+++ b/app/Livewire/Officer/Profile/ShowProfile.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Livewire\Officer\Profile;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+use Livewire\Component;
+
+class ShowProfile extends Component
+{
+    public $user;
+    public $officer;
+
+    public $passwordForm = [
+        'current_password' => '',
+        'password' => '',
+        'password_confirmation' => '',
+    ];
+
+    public $status = null;
+
+    public function mount(): void
+    {
+        $this->user = Auth::user()->load('officer');
+        $this->officer = $this->user->officer;
+    }
+
+    public function updatePassword(): void
+    {
+        $validated = $this->validate(
+            [
+                'passwordForm.current_password' => ['required', 'current_password'],
+                'passwordForm.password' => ['required', 'string', Password::defaults(), 'confirmed'],
+                'passwordForm.password_confirmation' => ['required'],
+            ],
+            [],
+            [
+                'passwordForm.current_password' => __('current password'),
+                'passwordForm.password' => __('password'),
+                'passwordForm.password_confirmation' => __('password confirmation'),
+            ]
+        );
+
+        $this->user->forceFill([
+            'password' => Hash::make($validated['passwordForm']['password']),
+        ])->save();
+
+        $this->passwordForm = [
+            'current_password' => '',
+            'password' => '',
+            'password_confirmation' => '',
+        ];
+
+        $this->status = 'password-updated';
+        session()->flash('status', __('Password berhasil diperbarui.'));
+    }
+
+    public function render()
+    {
+        return view('livewire.officer.profile.show-profile');
+    }
+}

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -166,7 +166,7 @@
                                 <i class="mdi mdi-chevron-down ms-1"></i>
                             </a>
                             <div class="dropdown-menu dd-menu dropdown-menu-end bg-white rounded shadow border-0 mt-3">
-                                <a href="{{ auth()->user()->is_kandidat ? route('profile.show') : route('officers.index') }}" class="dropdown-item fw-medium fs-6 d-flex align-items-center">
+                                <a href="{{ auth()->user()->is_kandidat ? route('profile.show') : route('officer.profile.show') }}" class="dropdown-item fw-medium fs-6 d-flex align-items-center">
                                     <i class="mdi mdi-account-outline me-2 align-middle"></i>
                                     <span>Profile</span>
                                 </a>

--- a/resources/views/livewire/officer/profile/show-profile.blade.php
+++ b/resources/views/livewire/officer/profile/show-profile.blade.php
@@ -1,0 +1,172 @@
+<div>
+    <!-- Hero Section -->
+    <section class="bg-half-170 d-table w-100" style="background: url('{{ asset('images/hero/bg.jpg') }}');">
+        <div class="bg-overlay bg-gradient-overlay"></div>
+        <div class="container">
+            <div class="row mt-5 justify-content-center">
+                <div class="col-12">
+                    <div class="title-heading text-center">
+                        <h5 class="heading fw-semibold mb-0 sub-heading text-white title-dark">{{ __('Profil Officer') }}</h5>
+                        <p class="text-white-50 para-desc mx-auto mb-0">{{ __('Kelola informasi akun dan keamanan kata sandi Anda di satu tempat.') }}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="position-middle-bottom">
+                <nav aria-label="breadcrumb" class="d-block">
+                    <ul class="breadcrumb breadcrumb-muted mb-0 p-0">
+                        <li class="breadcrumb-item"><a href="{{ route('officers.index') }}">{{ __('Beranda') }}</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">{{ __('Profil Officer') }}</li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </section>
+
+    <!-- Shape Divider -->
+    <div class="position-relative">
+        <div class="shape overflow-hidden text-white">
+            <svg viewBox="0 0 2880 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 48H1437.5H2880V0H2160C1442.5 52 720 0 720 0H0V48Z" fill="currentColor"></path>
+            </svg>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-10">
+                    @if (session('status'))
+                        <div class="alert alert-success alert-dismissible fade show shadow-sm" role="alert">
+                            <i class="mdi mdi-check-circle-outline me-1"></i>{{ session('status') }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                        </div>
+                    @endif
+
+                    <div class="row g-4 align-items-stretch">
+                        <!-- Profile Summary -->
+                        <div class="col-lg-5">
+                            <div class="card border-0 shadow h-100">
+                                <div class="card-body p-4">
+                                    <div class="d-flex align-items-center mb-4">
+                                        <div class="avatar avatar-lg bg-soft-primary text-primary rounded-circle d-flex align-items-center justify-content-center me-3" style="width:72px; height:72px;">
+                                            <i class="mdi mdi-shield-account-outline fs-1"></i>
+                                        </div>
+                                        <div>
+                                            <h5 class="fw-semibold mb-0">{{ $user->name }}</h5>
+                                            <span class="badge {{ $user->role_badge_class }} px-3 py-1 mt-2">{{ $user->role_badge_label }}</span>
+                                        </div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <p class="text-muted small mb-1">{{ __('Email') }}</p>
+                                        <p class="fw-medium text-dark mb-0">{{ $user->email }}</p>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <p class="text-muted small mb-1">{{ __('Jabatan') }}</p>
+                                        <p class="fw-medium text-dark mb-0">{{ optional($officer)->jabatan ?? __('Tidak tersedia') }}</p>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <p class="text-muted small mb-1">{{ __('Tanggal Bergabung') }}</p>
+                                        <p class="fw-medium text-dark mb-0">
+                                            @if(optional($officer)->doh)
+                                                {{ optional(optional($officer)->doh)->translatedFormat('d F Y') }}
+                                            @else
+                                                {{ __('Tidak tersedia') }}
+                                            @endif
+                                        </p>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <p class="text-muted small mb-1">{{ __('Lokasi Penugasan') }}</p>
+                                        <p class="fw-medium text-dark mb-0">{{ optional($officer)->lokasi_penugasan ?? __('Tidak tersedia') }}</p>
+                                    </div>
+
+                                    <div class="mb-0">
+                                        <p class="text-muted small mb-1">{{ __('Atasan Langsung') }}</p>
+                                        <p class="fw-medium text-dark mb-0">{{ optional(optional($officer)->atasan)->full_name ?? __('Tidak tersedia') }}</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Security Settings -->
+                        <div class="col-lg-7">
+                            <div class="card border-0 shadow h-100">
+                                <div class="card-header bg-primary text-white border-0 py-3 px-4">
+                                    <div class="d-flex align-items-center">
+                                        <span class="avatar-sm flex-shrink-0 bg-soft-light text-primary rounded-circle d-inline-flex align-items-center justify-content-center me-3">
+                                            <i class="mdi mdi-lock-reset"></i>
+                                        </span>
+                                        <div>
+                                            <h6 class="mb-0">{{ __('Keamanan Akun') }}</h6>
+                                            <small class="text-white-50">{{ __('Perbarui kata sandi Anda secara berkala untuk menjaga keamanan akun.') }}</small>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="card-body p-4">
+                                    <form wire:submit.prevent="updatePassword" class="needs-validation" novalidate>
+                                        <div class="mb-3">
+                                            <label for="current_password" class="form-label">{{ __('Kata Sandi Saat Ini') }} <span class="text-danger">*</span></label>
+                                            <div class="input-group">
+                                                <span class="input-group-text bg-light"><i class="mdi mdi-lock"></i></span>
+                                                <input type="password" id="current_password" class="form-control @error('passwordForm.current_password') is-invalid @enderror" wire:model.defer="passwordForm.current_password" placeholder="********" autocomplete="current-password">
+                                                @error('passwordForm.current_password')
+                                                    <div class="invalid-feedback d-block">{{ $message }}</div>
+                                                @enderror
+                                            </div>
+                                        </div>
+
+                                        <div class="row g-3">
+                                            <div class="col-md-6">
+                                                <label for="password" class="form-label">{{ __('Kata Sandi Baru') }} <span class="text-danger">*</span></label>
+                                                <div class="input-group">
+                                                    <span class="input-group-text bg-light"><i class="mdi mdi-lock-outline"></i></span>
+                                                    <input type="password" id="password" class="form-control @error('passwordForm.password') is-invalid @enderror" wire:model.defer="passwordForm.password" placeholder="********" autocomplete="new-password">
+                                                </div>
+                                                @error('passwordForm.password')
+                                                    <div class="invalid-feedback d-block">{{ $message }}</div>
+                                                @enderror
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label for="password_confirmation" class="form-label">{{ __('Konfirmasi Kata Sandi') }} <span class="text-danger">*</span></label>
+                                                <div class="input-group">
+                                                    <span class="input-group-text bg-light"><i class="mdi mdi-lock-check"></i></span>
+                                                    <input type="password" id="password_confirmation" class="form-control" wire:model.defer="passwordForm.password_confirmation" placeholder="********" autocomplete="new-password">
+                                                </div>
+                                                @error('passwordForm.password_confirmation')
+                                                    <div class="invalid-feedback d-block">{{ $message }}</div>
+                                                @enderror
+                                            </div>
+                                        </div>
+
+                                        <div class="alert bg-soft-warning text-warning border-0 mt-4" role="alert">
+                                            <div class="d-flex">
+                                                <i class="mdi mdi-shield-alert-outline me-2 fs-5"></i>
+                                                <div>
+                                                    <h6 class="mb-1 fw-semibold">{{ __('Tips Keamanan') }}</h6>
+                                                    <p class="mb-0 small">{{ __('Gunakan kombinasi huruf besar, huruf kecil, angka, dan simbol. Jangan gunakan kata sandi yang sama dengan akun lain.') }}</p>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="d-flex justify-content-end gap-2 mt-4">
+                                            <button type="reset" class="btn btn-outline-secondary" wire:click="$set('passwordForm', ['current_password' => '', 'password' => '', 'password_confirmation' => ''])">
+                                                <i class="mdi mdi-refresh me-1"></i>{{ __('Atur Ulang') }}
+                                            </button>
+                                            <button type="submit" class="btn btn-primary">
+                                                <i class="mdi mdi-content-save me-1"></i>{{ __('Perbarui Kata Sandi') }}
+                                            </button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -86,13 +86,16 @@
                         </x-slot>
 
                         <x-slot name="content">
-                            @php $role = strtolower(auth()->user()->role ?? ''); @endphp
+                            @php
+                                $role = strtolower(auth()->user()->role ?? '');
+                                $profileRouteName = $role === 'officer' ? 'officer.profile.show' : 'profile.show';
+                            @endphp
                             <!-- Account Management -->
                             <div class="block px-4 py-2 text-xs text-gray-400">
                                 {{ __('Manage Account') }}
                             </div>
 
-                            <x-dropdown-link href="{{ route('profile.show') }}">
+                            <x-dropdown-link href="{{ route($profileRouteName) }}">
                                 {{ __('Profile') }}
                             </x-dropdown-link>
 
@@ -160,9 +163,12 @@
             </div>
 
             <div class="mt-3 space-y-1">
-                @php $role = strtolower(auth()->user()->role ?? ''); @endphp
+                @php
+                    $role = strtolower(auth()->user()->role ?? '');
+                    $profileRouteName = $role === 'officer' ? 'officer.profile.show' : 'profile.show';
+                @endphp
                 <!-- Account Management -->
-                <x-responsive-nav-link href="{{ route('profile.show') }}" :active="request()->routeIs('profile.show')">
+                <x-responsive-nav-link href="{{ route($profileRouteName) }}" :active="request()->routeIs($profileRouteName)">
                     {{ __('Profile') }}
                 </x-responsive-nav-link>
 

--- a/resources/views/partials/navbar.blade.php
+++ b/resources/views/partials/navbar.blade.php
@@ -44,7 +44,7 @@
                                 <i class="mdi mdi-chevron-down ms-1"></i>
                             </a>
                             <div class="dropdown-menu dd-menu dropdown-menu-end bg-white rounded shadow border-0 mt-3">
-                                <a href="{{ auth()->user()->is_kandidat ? route('profile.show') : route('officers.index') }}" class="dropdown-item fw-medium fs-6 d-flex align-items-center">
+                                <a href="{{ auth()->user()->is_kandidat ? route('profile.show') : route('officer.profile.show') }}" class="dropdown-item fw-medium fs-6 d-flex align-items-center">
                                     <i data-feather="user" class="fea icon-sm me-2 align-middle"></i>
                                     <span>Profile</span>
                                 </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ Route::middleware([
     'role:officer', // pastikan user adalah officer
 ])->group(function () {
     Route::get('/officers', App\Livewire\Officer\Index::class)->name('officers.index');
+    Route::get('/officer/profile', App\Livewire\Officer\Profile\ShowProfile::class)->name('officer.profile.show');
 
     // Kategori Lowongan - manager, recruiter, coordinator
     Route::get('/kategori-lowongan', App\Livewire\KategoriLowongan\Index::class)


### PR DESCRIPTION
## Summary
- add a dedicated Livewire component and themed Blade view for officer profile management with password reset workflow
- update authenticated navigation drop-downs to direct officers to the new profile page
- register a protected route for the officer profile page within the officer middleware group

## Testing
- php artisan test *(fails: vendor dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca641662408326b2929718882c3c86