### PR TITLE
feat: add profile photo management for kandidat and officer

### DIFF
--- a/app/Livewire/Officer/Profile/ShowProfile.php
+++ b/app/Livewire/Officer/Profile/ShowProfile.php
@@ -6,9 +6,12 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 class ShowProfile extends Component
 {
+    use WithFileUploads;
+
     public $user;
     public $officer;
 
@@ -20,10 +23,44 @@ class ShowProfile extends Component
 
     public $status = null;
 
+    /**
+     * Temporary uploaded photo for officer profile.
+     *
+     * @var \Livewire\Features\SupportFileUploads\TemporaryUploadedFile|null
+     */
+    public $photo = null;
+
     public function mount(): void
     {
         $this->user = Auth::user()->load('officer');
         $this->officer = $this->user->officer;
+    }
+
+    public function saveProfilePhoto(): void
+    {
+        if (! $this->photo) {
+            $this->addError('photo', __('Silakan pilih foto profil terlebih dahulu.'));
+            return;
+        }
+
+        $this->validate([
+            'photo' => ['image', 'max:2048'],
+        ]);
+
+        $this->user->updateProfilePhoto($this->photo);
+        $this->user->refresh();
+        $this->photo = null;
+
+        session()->flash('status', __('Foto profil berhasil diperbarui.'));
+    }
+
+    public function removeProfilePhoto(): void
+    {
+        if ($this->user->profile_photo_path) {
+            $this->user->deleteProfilePhoto();
+            $this->user->refresh();
+            session()->flash('status', __('Foto profil berhasil dihapus.'));
+        }
     }
 
     public function updatePassword(): void

--- a/resources/views/livewire/officer/profile/show-profile.blade.php
+++ b/resources/views/livewire/officer/profile/show-profile.blade.php
@@ -48,15 +48,37 @@
                         <div class="col-lg-5">
                             <div class="card border-0 shadow h-100">
                                 <div class="card-body p-4">
-                                    <div class="d-flex align-items-center mb-4">
-                                        <div class="avatar avatar-lg bg-soft-primary text-primary rounded-circle d-flex align-items-center justify-content-center me-3" style="width:72px; height:72px;">
-                                            <i class="mdi mdi-shield-account-outline fs-1"></i>
+                                    <div class="text-center mb-4">
+                                        <div class="position-relative d-inline-block">
+                                            <img src="{{ $photo ? $photo->temporaryUrl() : $user->profile_photo_url }}" alt="{{ $user->name }}" class="rounded-circle object-cover border" style="width: 96px; height: 96px;">
+                                            <span class="position-absolute top-50 start-50 translate-middle d-none" wire:loading.class.remove="d-none" wire:target="photo">
+                                                <span class="spinner-border spinner-border-sm text-primary" role="status"></span>
+                                            </span>
                                         </div>
-                                        <div>
-                                            <h5 class="fw-semibold mb-0">{{ $user->name }}</h5>
-                                            <span class="badge {{ $user->role_badge_class }} px-3 py-1 mt-2">{{ $user->role_badge_label }}</span>
-                                        </div>
+                                        <h5 class="fw-semibold mb-0 mt-3">{{ $user->name }}</h5>
+                                        <span class="badge {{ $user->role_badge_class }} px-3 py-1 mt-2">{{ $user->role_badge_label }}</span>
                                     </div>
+
+                                    <form wire:submit.prevent="saveProfilePhoto" class="mb-4">
+                                        <div class="d-flex flex-wrap justify-content-center gap-2">
+                                            <label class="btn btn-outline-primary mb-0" for="officer-photo">
+                                                <i class="mdi mdi-camera me-1"></i>{{ __('Pilih Foto Baru') }}
+                                                <input type="file" id="officer-photo" class="d-none" wire:model.live="photo" accept="image/*">
+                                            </label>
+                                            @if($user->profile_photo_path)
+                                                <button type="button" class="btn btn-outline-danger" wire:click="removeProfilePhoto" wire:loading.attr="disabled" wire:target="removeProfilePhoto">
+                                                    <i class="mdi mdi-trash-can-outline me-1"></i>{{ __('Hapus Foto') }}
+                                                </button>
+                                            @endif
+                                            <button type="submit" class="btn btn-primary" wire:loading.attr="disabled" wire:target="saveProfilePhoto, photo">
+                                                <i class="mdi mdi-content-save me-1"></i>{{ __('Simpan Foto') }}
+                                            </button>
+                                        </div>
+                                        <p class="text-muted small mt-2 mb-0">{{ __('Format yang didukung: JPG, JPEG, PNG. Maksimal 2 MB.') }}</p>
+                                        @error('photo')
+                                            <div class="text-danger small mt-2">{{ $message }}</div>
+                                        @enderror
+                                    </form>
 
                                     <div class="mb-3">
                                         <p class="text-muted small mb-1">{{ __('Email') }}</p>

--- a/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
+++ b/resources/views/livewire/profile/update-kandidat-profile-form.blade.php
@@ -55,10 +55,41 @@
                                         <i class="mdi mdi-account-outline me-2"></i>Data Pribadi
                                     </h6>
                                 </div>
-                                
+
+                                <div class="col-12 mb-4">
+                                    <h6 class="fw-semibold mb-3">{{ __('Foto Profil') }}</h6>
+                                    <div class="d-flex flex-wrap align-items-center gap-3">
+                                        <div class="position-relative">
+                                            <img src="{{ $photo ? $photo->temporaryUrl() : optional($user)->profile_photo_url }}" alt="{{ optional($user)->name }}"
+                                                 class="rounded-circle object-cover" style="width: 96px; height: 96px;">
+                                            <div class="position-absolute top-50 start-50 translate-middle d-none" wire:loading.class.remove="d-none" wire:target="photo">
+                                                <span class="spinner-border spinner-border-sm text-primary" role="status"></span>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="d-flex flex-wrap gap-2">
+                                                <label class="btn btn-outline-primary mb-0" for="photo">
+                                                    <i class="mdi mdi-camera me-1"></i>{{ __('Pilih Foto Baru') }}
+                                                    <input type="file" id="photo" class="d-none" wire:model.live="photo" accept="image/*">
+                                                </label>
+                                                @if(optional($user)->profile_photo_path)
+                                                    <button type="button" class="btn btn-outline-danger" wire:click="removeProfilePhoto" wire:loading.attr="disabled" wire:target="removeProfilePhoto">
+                                                        <i class="mdi mdi-trash-can-outline me-1"></i>{{ __('Hapus Foto') }}
+                                                    </button>
+                                                @endif
+                                            </div>
+                                            <p class="text-muted small mb-0 mt-2">{{ __('Format yang didukung: JPG, JPEG, PNG. Maksimal 2 MB.') }}</p>
+                                            @error('photo')
+                                                <div class="text-danger small mt-2">{{ $message }}</div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <p class="text-muted small mb-0 mt-3">{{ __('Perubahan foto akan tersimpan setelah Anda menekan tombol Simpan Profil.') }}</p>
+                                </div>
+
                                 <div class="col-md-6 mb-3">
                                     <label for="nama_depan" class="form-label">{{ __('Nama Depan') }} <span class="text-danger">*</span></label>
-                                    <input id="nama_depan" type="text" class="form-control @error('state.nama_depan') is-invalid @enderror" 
+                                    <input id="nama_depan" type="text" class="form-control @error('state.nama_depan') is-invalid @enderror"
                                         wire:model.defer="state.nama_depan" autocomplete="given-name" placeholder="Masukkan nama depan">
                                     @error('state.nama_depan')
                                         <div class="invalid-feedback">{{ $message }}</div>


### PR DESCRIPTION
## Summary
- enable kandidat users to upload, replace, or remove their profile photo as part of the existing profile update flow
- add officer profile UI and Livewire handlers so officers can preview, change, or delete their avatar from the profile dashboard

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca667940848326b60d89d5af4f8196