### PR TITLE
Enable kandidat profile photo management from profile page

### DIFF
--- a/app/Livewire/Officer/Profile/ShowProfile.php
+++ b/app/Livewire/Officer/Profile/ShowProfile.php
@@ -38,6 +38,11 @@ class ShowProfile extends Component
 
     public function saveProfilePhoto(): void
     {
+        if (! $this->officer) {
+            $this->addError('photo', __('Profil officer belum tersedia.'));
+            return;
+        }
+
         if (! $this->photo) {
             $this->addError('photo', __('Silakan pilih foto profil terlebih dahulu.'));
             return;
@@ -56,11 +61,15 @@ class ShowProfile extends Component
 
     public function removeProfilePhoto(): void
     {
-        if ($this->officer && $this->officer->profile_photo_path) {
-            $this->officer->deleteProfilePhoto();
-            $this->officer->refresh();
-            session()->flash('status', __('Foto profil berhasil dihapus.'));
+        if (! $this->officer || ! $this->officer->profile_photo_path) {
+            return;
         }
+
+        $this->officer->deleteProfilePhoto();
+        $this->officer->refresh();
+        $this->photo = null;
+
+        session()->flash('status', __('Foto profil berhasil dihapus.'));
     }
 
     public function updatePassword(): void

--- a/app/Livewire/Profile/ShowProfile.php
+++ b/app/Livewire/Profile/ShowProfile.php
@@ -17,6 +17,13 @@ class ShowProfile extends Component
     public $kandidat;
 
     /**
+     * Temporary uploaded photo for kandidat profile.
+     *
+     * @var \Livewire\Features\SupportFileUploads\TemporaryUploadedFile|null
+     */
+    public $photo = null;
+
+    /**
      * Uploaded document placeholders
      */
     public $ktp;
@@ -39,6 +46,42 @@ class ShowProfile extends Component
         $this->kandidat = $user->kandidat;
 
         $this->refreshDocuments();
+    }
+
+    public function saveProfilePhoto(): void
+    {
+        if (! $this->kandidat) {
+            $this->addError('photo', __('Profil kandidat belum tersedia.')); // Guard when kandidat record missing
+            return;
+        }
+
+        if (! $this->photo) {
+            $this->addError('photo', __('Silakan pilih foto profil terlebih dahulu.'));
+            return;
+        }
+
+        $this->validate([
+            'photo' => ['image', 'max:2048'],
+        ]);
+
+        $this->kandidat->updateProfilePhoto($this->photo);
+        $this->kandidat->refresh();
+        $this->photo = null;
+
+        session()->flash('status', __('Foto profil berhasil diperbarui.'));
+    }
+
+    public function removeProfilePhoto(): void
+    {
+        if (! $this->kandidat || ! $this->kandidat->profile_photo_path) {
+            return;
+        }
+
+        $this->kandidat->deleteProfilePhoto();
+        $this->kandidat->refresh();
+        $this->photo = null;
+
+        session()->flash('status', __('Foto profil berhasil dihapus.'));
     }
 
     public function openDocumentModal($type = null)

--- a/app/Livewire/Profile/UpdateKandidatProfileForm.php
+++ b/app/Livewire/Profile/UpdateKandidatProfileForm.php
@@ -139,13 +139,14 @@ class UpdateKandidatProfileForm extends Component
         }
 
         // Gunakan updateOrCreate untuk membuat profil jika belum ada, atau memperbarui jika sudah ada
-        Kandidat::updateOrCreate(
+        $this->kandidat = Kandidat::updateOrCreate(
             ['user_id' => $user->id],
             $validatedData['state']
         );
 
-        if ($this->photo) {
+        if ($this->photo && $this->kandidat) {
             $this->kandidat->updateProfilePhoto($this->photo);
+            $this->kandidat->refresh();
             $this->photo = null;
         }
 

--- a/resources/views/livewire/officer/profile/show-profile.blade.php
+++ b/resources/views/livewire/officer/profile/show-profile.blade.php
@@ -49,13 +49,18 @@
                             <div class="card border-0 shadow h-100">
                                 <div class="card-body p-4">
                                     <div class="text-center mb-4">
+                                        @php
+                                            $currentPhotoUrl = $photo
+                                                ? $photo->temporaryUrl()
+                                                : (optional($officer)->profile_photo_url ?? optional($user)->profile_photo_url);
+                                        @endphp
                                         <div class="position-relative d-inline-block">
-                                            <img src="{{ $photo ? $photo->temporaryUrl() : $officer->profile_photo_url }}" alt="{{ $officer->full_name }}" class="rounded-circle object-cover border" style="width: 96px; height: 96px;">
+                                            <img src="{{ $currentPhotoUrl }}" alt="{{ optional($officer)->full_name ?? $user->name }}" class="rounded-circle object-cover border" style="width: 96px; height: 96px;">
                                             <span class="position-absolute top-50 start-50 translate-middle d-none" wire:loading.class.remove="d-none" wire:target="photo">
                                                 <span class="spinner-border spinner-border-sm text-primary" role="status"></span>
                                             </span>
                                         </div>
-                                        <h5 class="fw-semibold mb-0 mt-3">{{ $officer->full_name }}</h5>
+                                        <h5 class="fw-semibold mb-0 mt-3">{{ optional($officer)->full_name ?? $user->name }}</h5>
                                         <span class="badge {{ $user->role_badge_class }} px-3 py-1 mt-2">{{ $user->role_badge_label }}</span>
                                     </div>
 
@@ -65,7 +70,7 @@
                                                 <i class="mdi mdi-camera me-1"></i>{{ __('Pilih Foto Baru') }}
                                                 <input type="file" id="officer-photo" class="d-none" wire:model.live="photo" accept="image/*">
                                             </label>
-                                            @if($officer && $officer->profile_photo_path)
+                                            @if(optional($officer)->profile_photo_path)
                                                 <button type="button" class="btn btn-outline-danger" wire:click="removeProfilePhoto" wire:loading.attr="disabled" wire:target="removeProfilePhoto">
                                                     <i class="mdi mdi-trash-can-outline me-1"></i>{{ __('Hapus Foto') }}
                                                 </button>

--- a/resources/views/livewire/profile/show-profile.blade.php
+++ b/resources/views/livewire/profile/show-profile.blade.php
@@ -55,7 +55,57 @@
                         </div>
 
                         <div class="card-body p-4">
+                            @foreach (['status', 'success'] as $flashKey)
+                                @if (session($flashKey))
+                                    <div class="alert alert-success alert-dismissible fade show shadow-sm" role="alert">
+                                        <i class="mdi mdi-check-circle-outline me-1"></i>{{ session($flashKey) }}
+                                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                                    </div>
+                                @endif
+                            @endforeach
+
                             @if ($kandidat)
+                                <div class="row">
+                                    <div class="col-12 mb-4">
+                                        <h6 class="fw-bold text-primary border-bottom pb-2">
+                                            <i class="mdi mdi-camera-account me-2"></i>Foto Profil
+                                        </h6>
+                                        <form wire:submit.prevent="saveProfilePhoto" class="d-flex flex-wrap align-items-center gap-3">
+                                            @php
+                                                $currentPhotoUrl = $photo
+                                                    ? $photo->temporaryUrl()
+                                                    : (optional($kandidat)->profile_photo_url ?? Auth::user()->profile_photo_url);
+                                            @endphp
+                                            <div class="position-relative">
+                                                <img src="{{ $currentPhotoUrl }}" alt="{{ optional($kandidat)->full_name ?? Auth::user()->name }}" class="rounded-circle object-cover border" style="width: 96px; height: 96px;">
+                                                <div class="position-absolute top-50 start-50 translate-middle d-none" wire:loading.class.remove="d-none" wire:target="photo">
+                                                    <span class="spinner-border spinner-border-sm text-primary" role="status"></span>
+                                                </div>
+                                            </div>
+                                            <div class="flex-grow-1">
+                                                <div class="d-flex flex-wrap gap-2">
+                                                    <label class="btn btn-outline-primary mb-0" for="kandidat-photo">
+                                                        <i class="mdi mdi-camera me-1"></i>{{ __('Pilih Foto Baru') }}
+                                                        <input type="file" id="kandidat-photo" class="d-none" wire:model.live="photo" accept="image/*">
+                                                    </label>
+                                                    @if (optional($kandidat)->profile_photo_path)
+                                                        <button type="button" class="btn btn-outline-danger" wire:click="removeProfilePhoto" wire:loading.attr="disabled" wire:target="removeProfilePhoto">
+                                                            <i class="mdi mdi-trash-can-outline me-1"></i>{{ __('Hapus Foto') }}
+                                                        </button>
+                                                    @endif
+                                                    <button type="submit" class="btn btn-primary" wire:loading.attr="disabled" wire:target="saveProfilePhoto, photo">
+                                                        <i class="mdi mdi-content-save me-1"></i>{{ __('Simpan Foto') }}
+                                                    </button>
+                                                </div>
+                                                <p class="text-muted small mb-0 mt-2">{{ __('Format yang didukung: JPG, JPEG, PNG. Maksimal 2 MB.') }}</p>
+                                                @error('photo')
+                                                    <div class="text-danger small mt-2">{{ $message }}</div>
+                                                @enderror
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+
                                 {{-- Data Test Section --}}
                                 <div class="row">
                                     <div class="col-12 mb-4">


### PR DESCRIPTION
## Summary
- add Livewire actions to save and remove kandidat profile photos directly from the profile component
- expose profile photo management controls on the kandidat profile page with status feedback and previews
- refresh the kandidat model after update-or-create so newly created profiles can persist uploaded photos
- enable officer profile photo uploads/removals with guards and UI fallbacks on the officer profile page

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca74c2e35c83268f69a27e8af17c84